### PR TITLE
client: Call the stream level error handler receipt of RST_STREAM frames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Unreleased
   ([#40](https://github.com/anmonteiro/ocaml-h2/pull/40))
 - h2: improve handling of received frames against closed streams
   ([#40](https://github.com/anmonteiro/ocaml-h2/pull/40))
+- h2: in the client implementation, call the stream level error handler when
+  receiving an `RST_STREAM` frame
+  ([#42](https://github.com/anmonteiro/ocaml-h2/pull/42))
 
 0.2.0 2019-04-06
 --------------

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ One of h2's goals is to be 100% compliant with the HTTP/2 specification.
 There are currently 3 mechanisms in place to verify such conformance:
 
 1. Unit tests using the HPACK stories in the
-   [http2jp/hpack-test-case](https://github.com/http2jp/hpack-test-case).
+   [http2jp/hpack-test-case](https://github.com/http2jp/hpack-test-case)
    repository
 2. Unit tests using the test cases provided by the
    [http2jp/http2-frame-test-case](https://github.com/http2jp/http2-frame-test-case)


### PR DESCRIPTION
that are not treated as connection errors