### PR TITLE
h2 server: Don't abide by the max concurrent streams setting that the client sends to check whether the client can open streams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ Unreleased
   ([#65](https://github.com/anmonteiro/ocaml-h2/pull/65))
 - h2-lwt, h2-lwt-unix, h2-mirage: Expose `Client.is_closed`
   ([#65](https://github.com/anmonteiro/ocaml-h2/pull/65))
+- h2: Don't count peer max concurrent streams based on what the endpoint
+  receives; the endpoint is responsible for selecting it
+  ([#71](https://github.com/anmonteiro/ocaml-h2/pull/71))
 
 0.3.0 2019-05-04
 --------------

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -352,7 +352,7 @@ let handle_headers t ~end_stream respd headers =
    *   receives a HEADERS frame that causes its advertised concurrent stream
    *   limit to be exceeded MUST treat this as a stream error (Section 5.4.2)
    *   of type PROTOCOL_ERROR or REFUSED_STREAM. *)
-  if t.current_server_streams + 1 > t.settings.max_concurrent_streams then
+  if t.current_server_streams + 1 > t.config.max_concurrent_streams then
     if t.unacked_settings > 0 then
       (* From RFC7540§8.1.4:
        *   The REFUSED_STREAM error code can be included in a RST_STREAM frame

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -232,7 +232,7 @@ let handle_headers t ~end_stream reqd active_stream headers =
    *   receives a HEADERS frame that causes its advertised concurrent stream
    *   limit to be exceeded MUST treat this as a stream error (Section 5.4.2)
    *   of type PROTOCOL_ERROR or REFUSED_STREAM. *)
-  if t.current_client_streams + 1 > t.settings.max_concurrent_streams then
+  if t.current_client_streams + 1 > t.config.max_concurrent_streams then
     if t.unacked_settings > 0 then
       (* From RFC7540§8.1.4:
        *   The REFUSED_STREAM error code can be included in a RST_STREAM frame


### PR DESCRIPTION
From https://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2:

> That is, clients specify the maximum number of concurrent streams the server can initiate, and servers specify the maximum number of concurrent streams the client can initiate.

TODO:

- [x] Also fix on the client
- [x] Changelog entry