### PR TITLE
Added method to send headers trailers with stream

### DIFF
--- a/lib/h2.mli
+++ b/lib/h2.mli
@@ -504,6 +504,8 @@ module Reqd : sig
       From {{:https://tools.ietf.org/html/rfc7540#section-8.1} RFC7540§8.1}:
       An HTTP request/response exchange fully consumes a single stream. *)
 
+  val send_trailer_headers : t -> Headers.t -> unit
+
   val respond_with_string : t -> Response.t -> string -> unit
 
   val respond_with_bigstring : t -> Response.t -> Bigstringaf.t -> unit

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -238,11 +238,14 @@ let send_trailer_headers t headers =
       Writer.make_frame_info
         ~max_frame_size:t.max_frame_size
         ~flags:(Flags.default_flags |> Flags.set_end_stream)
-        t.id in
+        t.id
+    in
     Writer.write_trailer_headers t.writer stream.encoder frame_info headers;
     Stream.finish_stream t Finished
   | _ ->
-    failwith "h2.Reqd.send_trailer_headers: invalid state, can be called only after respond_with_streaming"
+    failwith
+      "h2.Reqd.send_trailer_headers: invalid state, can be called only after \
+       respond_with_streaming"
 
 let send_streaming_response ~flush_headers_immediately t s response =
   s.wait_for_first_flush <- not flush_headers_immediately;

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -531,6 +531,17 @@ module Writer = struct
       ~has_priority
       faraday
 
+  let write_trailer_headers t hpack_encoder ?priority frame_info headers =
+    let faraday = Faraday.of_bigstring t.headers_block_buffer in
+    encode_headers hpack_encoder faraday headers;
+    let has_priority = match priority with Some _ -> true | None -> false in
+    chunk_header_block_fragments
+      t
+      frame_info
+      ~write_frame:(write_headers_frame ?priority)
+      ~has_priority
+      faraday
+  
   let write_rst_stream t frame_info e =
     write_rst_stream_frame t.encoder frame_info e
 


### PR DESCRIPTION
I'm not sure about anything here, it's mainly for brainstorming, the current API is

## Current API
**pros**: simple to implement and doesn't need to change anything just add some functions
**cons**: not great and you can quite easily call it with an invalid state by accident
```ocaml
let body = Reqd.respond_with_streaming rd res
(* can only be called between respond_with_streaming  and close_writer *)
Reqd.send_trailer_headers request_descriptor headers;
Body.close_writer response_body
```

## Better API
**pros**: cleaner, can't be called with an invalid state
**cons**: will need to change a bunch of things and I'm not sure if that's a great idea

It needs to pass `Writer.t` or a callback with the signature of `Headers.t -> unit` for inside of `Body.t`.
```ocaml
let body = Reqd.respond_with_streaming rd res
Body.close_writer response_body ~trailer:headers
```

Also I'm not sure how to test them, have zero experience writing tests in Ocaml