### PR TITLE
h2c support: start server stream in the half-closed (remote) state

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -35,9 +35,9 @@
   "resolutions": {
     "@opam/conf-libev": "esy-packages/libev:package.json#0b5eb66",
     "@opam/conf-libssl": "esy-packages/esy-openssl#860ad7f",
-    "@opam/httpaf": "anmonteiro/httpaf:httpaf.opam#b01626b",
-    "@opam/httpaf-lwt": "anmonteiro/httpaf:httpaf-lwt.opam#b01626b",
-    "@opam/httpaf-lwt-unix": "anmonteiro/httpaf:httpaf-lwt-unix.opam#b01626b",
+    "@opam/httpaf": "anmonteiro/httpaf:httpaf.opam#ec526a5",
+    "@opam/httpaf-lwt": "anmonteiro/httpaf:httpaf-lwt.opam#ec526a5",
+    "@opam/httpaf-lwt-unix": "anmonteiro/httpaf:httpaf-lwt-unix.opam#ec526a5",
     "@opam/ssl": "savonet/ocaml-ssl:ssl.opam#0111764"
   }
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "48b98bb8c9715611181ae9c7487aff2e",
+  "checksum": "f92d1f78536eafe9dd2b13e89f8b4867",
   "root": "h2@link-dev:./esy.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -45,8 +45,8 @@
         "@opam/psq@opam:0.2.0@247756d4",
         "@opam/mirage-flow@opam:2.0.1@b9cf2b19",
         "@opam/lwt_ssl@opam:1.1.3@9d044ebe", "@opam/lwt@opam:4.4.0@0357bb8b",
-        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#b01626b@d41d8cd9",
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#b01626b@d41d8cd9",
+        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#ec526a5@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#ec526a5@d41d8cd9",
         "@opam/faraday-lwt-unix@opam:0.7.0@52a60108",
         "@opam/faraday@opam:0.7.0@6d4772f6",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
@@ -2122,61 +2122,61 @@
         "@opam/bigarray-compat@opam:1.0.0@1faefa97"
       ]
     },
-    "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#b01626b@d41d8cd9": {
+    "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#ec526a5@d41d8cd9": {
       "id":
-        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#b01626b@d41d8cd9",
+        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#ec526a5@d41d8cd9",
       "name": "@opam/httpaf-lwt-unix",
-      "version": "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#b01626b",
+      "version": "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#ec526a5",
       "source": {
         "type": "install",
-        "source": [ "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#b01626b" ]
+        "source": [ "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#ec526a5" ]
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/tls@opam:0.10.5@06575639",
         "@opam/lwt_ssl@opam:1.1.3@9d044ebe", "@opam/lwt@opam:4.4.0@0357bb8b",
-        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#b01626b@d41d8cd9",
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#b01626b@d41d8cd9",
+        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#ec526a5@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#ec526a5@d41d8cd9",
         "@opam/faraday-lwt-unix@opam:0.7.0@52a60108",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/lwt@opam:4.4.0@0357bb8b",
-        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#b01626b@d41d8cd9",
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#b01626b@d41d8cd9",
+        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#ec526a5@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#ec526a5@d41d8cd9",
         "@opam/faraday-lwt-unix@opam:0.7.0@52a60108",
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
-    "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#b01626b@d41d8cd9": {
+    "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#ec526a5@d41d8cd9": {
       "id":
-        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#b01626b@d41d8cd9",
+        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#ec526a5@d41d8cd9",
       "name": "@opam/httpaf-lwt",
-      "version": "github:anmonteiro/httpaf:httpaf-lwt.opam#b01626b",
+      "version": "github:anmonteiro/httpaf:httpaf-lwt.opam#ec526a5",
       "source": {
         "type": "install",
-        "source": [ "github:anmonteiro/httpaf:httpaf-lwt.opam#b01626b" ]
+        "source": [ "github:anmonteiro/httpaf:httpaf-lwt.opam#ec526a5" ]
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/lwt@opam:4.4.0@0357bb8b",
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#b01626b@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#ec526a5@d41d8cd9",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/lwt@opam:4.4.0@0357bb8b",
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#b01626b@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#ec526a5@d41d8cd9",
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
-    "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#b01626b@d41d8cd9": {
+    "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#ec526a5@d41d8cd9": {
       "id":
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#b01626b@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#ec526a5@d41d8cd9",
       "name": "@opam/httpaf",
-      "version": "github:anmonteiro/httpaf:httpaf.opam#b01626b",
+      "version": "github:anmonteiro/httpaf:httpaf.opam#ec526a5",
       "source": {
         "type": "install",
-        "source": [ "github:anmonteiro/httpaf:httpaf.opam#b01626b" ]
+        "source": [ "github:anmonteiro/httpaf:httpaf.opam#ec526a5" ]
       },
       "overrides": [],
       "dependencies": [

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -1250,14 +1250,14 @@ let handle_h2c_request t headers request_body_iovecs =
     let request = Reqd.request reqd in
     let request_body = Reqd.request_body reqd in
     let request_info = Reqd.create_active_request request request_body in
+    request_info.request_body_bytes <-
+      Int64.(add request_info.request_body_bytes (of_int lengthv));
     (* From RFC7540§3.2:
      *   Stream 1 is implicitly "half-closed" from the client toward the server
      *   (see Section 5.1), since the request is completed as an HTTP/1.1
      *   request. After commencing the HTTP/2 connection, stream 1 is used for
      *   the response. *)
     reqd.state <- Active (HalfClosed request_info, active_stream);
-    request_info.request_body_bytes <-
-      Int64.(add request_info.request_body_bytes (of_int lengthv));
     if not end_stream then
       let faraday = Body.unsafe_faraday request_body in
       if not (Faraday.is_closed faraday) then (

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -1243,20 +1243,23 @@ let handle_h2c_request t headers request_body_iovecs =
         (fun () -> wakeup_writer t)
         (create_push_stream t)
     in
+    t.max_client_stream_id <- reqd.Stream.id;
+    let lengthv = Httpaf.IOVec.lengthv request_body_iovecs in
+    let end_stream = lengthv = 0 in
+    handle_headers t ~end_stream reqd active_stream headers;
+    let request = Reqd.request reqd in
+    let request_body = Reqd.request_body reqd in
+    let request_info = Reqd.create_active_request request request_body in
     (* From RFC7540§3.2:
      *   Stream 1 is implicitly "half-closed" from the client toward the server
      *   (see Section 5.1), since the request is completed as an HTTP/1.1
      *   request. After commencing the HTTP/2 connection, stream 1 is used for
      *   the response. *)
-    t.max_client_stream_id <- reqd.Stream.id;
-    let end_stream = Httpaf.IOVec.lengthv request_body_iovecs = 0 in
-    handle_headers t ~end_stream reqd active_stream headers;
+    reqd.state <- Active (HalfClosed request_info, active_stream);
+    request_info.request_body_bytes <-
+      Int64.(add request_info.request_body_bytes (of_int lengthv));
     if not end_stream then
-      let request_body = Reqd.request_body reqd in
       let faraday = Body.unsafe_faraday request_body in
-      (* Don't bother changing request info body_bytes because its only use is to
-       * check message body length when DATA frames arrive, and we aren't expecting
-       * any. *)
       if not (Faraday.is_closed faraday) then (
         List.iter
           (fun { Httpaf.IOVec.buffer; off; len } ->


### PR DESCRIPTION
This fixes a race condition that caused H2 to send an unecessary Stream
Error of `NoError` when handling the first h2c request.

Also bumps the http/af resolution