### PR TITLE
Fix misinterpretation of the spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ Unreleased
   "http" URIs. Covers [section 3.2](https://tools.ietf.org/html/rfc7540#section-3.2)
   of the HTTP/2 specification
   ([#87](https://github.com/anmonteiro/httpaf/pull/87))
+- h2: Fix misinterpretation of the spec where h2 would consider a request /
+  response malformed if it had a non-zero `content-length` header and no DATA
+  frames ([#89](https://github.com/anmonteiro/httpaf/pull/89))
 
 0.4.0 2019-11-05
 --------------

--- a/lib_test/test_h2_server.ml
+++ b/lib_test/test_h2_server.ml
@@ -925,6 +925,19 @@ module Server_connection_tests = struct
     | Error msg ->
       Alcotest.fail msg
 
+  let test_nonzero_content_length_no_data_frames () =
+    let request =
+      Request.create
+        ~headers:(Headers.of_list [ "content-length", "1234" ])
+        ~scheme:"http"
+        `GET
+        "/"
+    in
+    let t = create_and_handle_preface ~error_handler default_request_handler in
+    read_request t request;
+    write_response t ?body:None (Response.create `OK);
+    writer_yields t
+
   (* TODO: test for trailer headers. *)
   (* TODO: test graceful shutdown, allowing lower numbered streams to complete. *)
   let suite =
@@ -968,6 +981,9 @@ module Server_connection_tests = struct
       , `Quick
       , test_empty_fixed_streaming_response )
     ; "starting an h2c connection", `Quick, test_h2c
+    ; ( "non-zero `content-length` and no DATA frames"
+      , `Quick
+      , test_nonzero_content_length_no_data_frames )
     ]
 end
 


### PR DESCRIPTION
requests /responses are allowed to have non-zero `content-length`
headers and no DATA frames

still needs a test