### PR TITLE
fix premature SSL termination

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Unreleased
   ([#108](https://github.com/anmonteiro/httpaf/pull/108))
 - h2-lwt-unix: fix premature SSL termination in the SSL / TLS runtimes
   ([#109](https://github.com/anmonteiro/httpaf/pull/109))
+- h2-lwt-unix: TLS runtime: adapt to TLS v0.11.0
+  ([#109](https://github.com/anmonteiro/httpaf/pull/109))
 
 0.5.0 2019-12-19
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Unreleased
   ([#94](https://github.com/anmonteiro/httpaf/pull/94))
 - h2-lwt: Close the communication channel after shutting down the client
   ([#108](https://github.com/anmonteiro/httpaf/pull/108))
+- h2-lwt-unix: fix premature SSL termination in the SSL / TLS runtimes
+  ([#109](https://github.com/anmonteiro/httpaf/pull/109))
 
 0.5.0 2019-12-19
 --------------

--- a/async/h2_async.ml
+++ b/async/h2_async.ml
@@ -324,7 +324,8 @@ module Make_client (Io : IO) = struct
         Client_connection.yield_writer connection writer_thread
       | `Close _ ->
         (* Log.Global.printf "write_close(%d)%!" (Fd.to_int_exn fd); *)
-        Ivar.fill write_complete ()
+        Ivar.fill write_complete ();
+        Io.shutdown_send socket
     in
     let conn_monitor = Monitor.create () in
     Scheduler.within ~monitor:conn_monitor reader_thread;

--- a/examples/lwt/dune
+++ b/examples/lwt/dune
@@ -1,6 +1,12 @@
 (executables
- (names lwt_h2c lwt_echo_server2 lwt_https_server lwt_get lwt_post)
- (libraries base64 h2 httpaf httpaf-lwt-unix h2-lwt-unix lwt lwt.unix))
+ (names lwt_echo_server2 lwt_https_server lwt_get lwt_post)
+ (modules lwt_echo_server2 lwt_https_server lwt_get lwt_post)
+ (libraries h2-lwt-unix lwt.unix))
+
+(executable
+ (name lwt_h2c)
+ (libraries httpaf-lwt-unix h2-lwt-unix lwt.unix)
+ (modules lwt_h2c))
 
 (alias
  (name examples)

--- a/h2-lwt-unix.opam
+++ b/h2-lwt-unix.opam
@@ -16,7 +16,10 @@ depends: [
   "dune" {>= "1.5"}
   "lwt"
 ]
-depopts: ["tls" "lwt_ssl"]
+depopts: [
+  "tls" {>= "0.11.0"}
+  "lwt_ssl"
+]
 synopsis: "Lwt + UNIX support for h2"
 description: """
 h2 is an implementation of the HTTP/2 specification entirely in OCaml.

--- a/h2-lwt-unix.opam
+++ b/h2-lwt-unix.opam
@@ -17,7 +17,7 @@ depends: [
   "lwt"
 ]
 depopts: [
-  "tls" {>= "0.11.0"}
+  "tls"
   "lwt_ssl"
 ]
 synopsis: "Lwt + UNIX support for h2"

--- a/lwt-unix/tls_io_real.ml
+++ b/lwt-unix/tls_io_real.ml
@@ -82,9 +82,12 @@ module Io :
     match Tls_lwt.Unix.epoch tls with `Error -> `Error | `Ok _ -> `Open
 end
 
+let null_auth ~host:_ _ = Ok None
+
 let make_client socket =
-  X509_lwt.authenticator `No_authentication_I'M_STUPID >>= fun authenticator ->
-  let config = Tls.Config.client ~authenticator ~alpn_protocols:[ "h2" ] () in
+  let config =
+    Tls.Config.client ~authenticator:null_auth ~alpn_protocols:[ "h2" ] ()
+  in
   Tls_lwt.Unix.client_of_fd config socket
 
 (* This function does not perform error handling and will therefore crash a

--- a/lwt/h2_lwt.ml
+++ b/lwt/h2_lwt.ml
@@ -258,6 +258,7 @@ module Client (Io : IO) = struct
           Lwt.return_unit
         | `Close _ ->
           Lwt.wakeup_later notify_write_loop_exited ();
+          Io.shutdown_send socket;
           Lwt.return_unit
       in
       Lwt.async (fun () ->

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,8 +2,8 @@
 
 let
   overlays = builtins.fetchTarball {
-    url = https://github.com/anmonteiro/nix-overlays/archive/79040d1.tar.gz;
-    sha256 = "0a7sdxihp8nsggh3a535b0gb9mnjbwa48d4fj2rw4n18223la1wg";
+    url = https://github.com/anmonteiro/nix-overlays/archive/878e180.tar.gz;
+    sha256 = "1zbdnsaxj2xxsy3kz7rc5ziqlmwf6ba9pvs6pwvhf77xgr08blm0";
   };
 
 in


### PR DESCRIPTION
same as https://github.com/anmonteiro/httpaf/pull/47

also adapt the TLS IO layer to the v0.11 interface