### PR TITLE
Set valid dune version for fmt 1.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 1.5)
+(lang dune 1.7)
 (using fmt 1.1)
 (name h2)
 

--- a/h2-async.opam
+++ b/h2-async.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06"}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "faraday-async"
   "async"
   "h2" {= version}

--- a/h2-lwt-unix.opam
+++ b/h2-lwt-unix.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "faraday-lwt-unix"
   "h2-lwt" {= version}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "lwt"
   "gluten-lwt-unix" {>= "0.2.0"}
 ]

--- a/h2-lwt.opam
+++ b/h2-lwt.opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06"}
   "h2" {= version}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "lwt"
   "gluten-lwt" {>= "0.2.0"}
 ]

--- a/h2-mirage.opam
+++ b/h2-mirage.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "faraday-lwt"
   "h2-lwt" {= version}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "lwt"
   "conduit-mirage" {>= "2.0.2"}
   "mirage-flow" {>= "2.0.0"}

--- a/h2.opam
+++ b/h2.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06"}
-  "dune" {>= "1.5"}
+  "dune" {>= "1.7"}
   "alcotest" {with-test}
   "yojson" {with-test}
   "hex" {with-test}

--- a/hpack.opam
+++ b/hpack.opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
 doc: "https://anmonteiro.github.io/ocaml-h2/"
 depends: [
   "ocaml" {>= "4.04"}
-  "dune"
+  "dune" {>= "1.7"}
   "yojson" {with-test}
   "hex" {with-test}
   "angstrom"


### PR DESCRIPTION
# Warning: Version 1.1 of integration with automatic formatters is not
# supported until version 1.7 of the dune language.
# Supported versions of this extension in version 1.5 of the dune language:
# - 1.0