### PR TITLE
Move yield / wake up behavior to writer

### DIFF
--- a/async/h2_async_intf.ml
+++ b/async/h2_async_intf.ml
@@ -44,7 +44,7 @@ module type IO = sig
     -> off:int
     -> len:int
     -> [ `Eof | `Ok of int ] Deferred.t
-  (** The region [[off, off + len)] is where read bytes can be written to *)
+  (** The region [(off, off + len)] is where read bytes can be written to *)
 
   val writev
     :  socket

--- a/lib/respd.ml
+++ b/lib/respd.ml
@@ -63,7 +63,6 @@ type active_request =
   { request : Request.t
   ; request_body : [ `writer ] Body.t
   ; response_handler : response_handler
-  ; wakeup_writer : Optional_thunk.t
   }
 
 type active_state =


### PR DESCRIPTION
This makes the code much simpler.

Similar to https://github.com/anmonteiro/httpaf/pull/67 and the upstream
http/af changes