### PR TITLE
Don't put the parser in an error state when (force-)closing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,18 @@
+Unreleased
+---------------
+- h2-async: add Async adapter
+  ([#94](https://github.com/anmonteiro/ocaml-h2/pull/94))
+- h2-async: Use [gluten](https://github.com/anmonteiro/gluten) to implement
+  h2-async ([#125](https://github.com/anmonteiro/ocaml-h2/pull/125))
+- h2-mirage: Use [gluten](https://github.com/anmonteiro/gluten) to implement
+  h2-mirage ([#120](https://github.com/anmonteiro/ocaml-h2/pull/120))
+- h2: Don't put parser in error state when force-closing
+  ([#127](https://github.com/anmonteiro/ocaml-h2/pull/127))
+
+
 0.6.0 2020-04-29
 --------------
 
-- h2-async: add Async adapter
-  ([#94](https://github.com/anmonteiro/ocaml-h2/pull/94))
 - h2-lwt: Close the communication channel after shutting down the client
   ([#108](https://github.com/anmonteiro/ocaml-h2/pull/108))
 - h2-lwt-unix: fix premature SSL termination in the SSL / TLS runtimes
@@ -22,14 +32,10 @@
 - h2: in the client implementation, don't report an error if the server has
   sent an `RST_STREAM` frame after sending a complete response
   ([#119](https://github.com/anmonteiro/ocaml-h2/pull/119)).
-- h2-mirage: Use [gluten](https://github.com/anmonteiro/gluten) to implement
-  h2-mirage ([#120](https://github.com/anmonteiro/ocaml-h2/pull/120))
 - h2-lwt-unix: fix a regression that prevented the SSL / TLS runtimes to
   negotiate an HTTP/2 connection over the ALPN extension of TLS, in their
   default implementations
   ([#122](https://github.com/anmonteiro/ocaml-h2/pull/122))
-- h2-async: Use [gluten](https://github.com/anmonteiro/gluten) to implement
-  h2-async ([#125](https://github.com/anmonteiro/ocaml-h2/pull/125))
 
 0.5.0 2019-12-19
 --------------

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -161,7 +161,12 @@ let report_connection_error t ?(additional_debug_data = "") error =
 let report_stream_error t stream_id error =
   report_error t (StreamError (stream_id, error))
 
-let shutdown t = report_connection_error t Error_code.NoError
+let shutdown t =
+  (* From RFC7540§6.8:
+   *   A server that is attempting to gracefully shut down a connection SHOULD
+   *   send an initial GOAWAY frame with the last stream identifier set to
+   *   2^31-1 and a NO_ERROR code. *)
+  report_connection_error t Error_code.NoError
 
 let set_error_and_handle t stream error error_code =
   Respd.report_error stream error error_code;

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/36019ba.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/af504f1.tar.gz;
 
 in
 


### PR DESCRIPTION
Avoid feeding any input (including the empty bigstring) to the parser
when (force-)closing the reader. This prevents bug where the reader would
report an error state (or worse, a stream-error state that wants to keep
reading frames) when a connection is shutdown.