### PR TITLE
client / server: execute request/response body reads as data frames arrive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ---------------
 
+- h2: client / server: execute request/response body reads as data frames
+  arrive ([#130](https://github.com/anmonteiro/ocaml-h2/pull/130))
+
 0.6.1 2020-05-16
 ---------------
 - h2-async: add Async adapter

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -1,5 +1,11 @@
 open H2__
 
+module Option = struct
+  let get = function Some x -> x | None -> failwith "Option.get: None"
+
+  let map f = function Some x -> Some (f x) | None -> None
+end
+
 let read_all path =
   let file = open_in path in
   try really_input_string file (in_channel_length file) with

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -43,7 +43,7 @@ in
       h2-lwt = buildH2 {
         pname = "h2-lwt";
         doCheck = false;
-        propagatedBuildInputs = [ h2 lwt4 gluten-lwt ];
+        propagatedBuildInputs = [ h2 lwt gluten-lwt ];
       };
 
       h2-lwt-unix = buildH2 {

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/3d2d00a7.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/70347e97.tar.gz;
 
 in
 


### PR DESCRIPTION

this fixes a latency issue where H2 used to (incorrectly )wait for the
entire body to arrive before starting to schedule reads.