### PR TITLE
Flow control: only give back flow control tokens after surfacing reads to the application

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Unreleased
 
 - h2: client / server: execute request/response body reads as data frames
   arrive ([#130](https://github.com/anmonteiro/ocaml-h2/pull/130))
+- h2: client / server: only give back flow control tokens after surfacing reads
+  to the application ([#131](https://github.com/anmonteiro/ocaml-h2/pull/131))
 
 0.6.1 2020-05-16
 ---------------

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -1079,8 +1079,8 @@ let process_window_update_frame t { Frame.frame_header; _ } window_increment =
    *   connection. In the former case, the frame's stream identifier indicates
    *   the affected stream; in the latter, the value "0" indicates that the
    *   entire connection is the subject of the frame. *)
-  if Stream_identifier.is_connection stream_id then (
-    add_window_increment t t.streams window_increment)
+  if Stream_identifier.is_connection stream_id then
+    add_window_increment t t.streams window_increment
   else
     match Scheduler.get_node t.streams stream_id with
     | Some (Stream { descriptor; _ } as stream_node) ->

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -58,20 +58,20 @@ let default =
      *   endpoint MUST be between this initial value and the maximum allowed
      *   frame size (2^24-1 or 16,777,215 octets), inclusive. *)
     read_buffer_size = Settings.default.max_frame_size
-  ; request_body_buffer_size = 0x1000 (* Buffer size for request bodies *)
-  ; response_body_buffer_size = 0x1000 (* Buffer size for response bodies *)
-  ; enable_server_push =
-      true
-      (* From RFC7540§6.5.2:
-       *   Indicates the maximum number of concurrent streams that the sender
-       *   will allow. This limit is directional: it applies to the number of
-       *   streams that the sender permits the receiver to create. *)
-  ; max_concurrent_streams =
-      Settings.default.max_concurrent_streams
-      (* From RFC7540§6.5.2:
-       *   Indicates the sender's initial window size (in octets) for
-       *   stream-level flow control. *)
-  ; initial_window_size = Settings.WindowSize.default_initial_window_size
+  ; (* Buffer size for request bodies *) request_body_buffer_size = 0x1000
+  ; (* Buffer size for response bodies *) response_body_buffer_size = 0x1000
+  ; enable_server_push = true
+  ; (* From RFC7540§6.5.2:
+     *   Indicates the maximum number of concurrent streams that the sender
+     *   will allow. This limit is directional: it applies to the number of
+     *   streams that the sender permits the receiver to create. *)
+    max_concurrent_streams = Settings.default.max_concurrent_streams
+  ; (* Indicates the initial window size when receiving data from remote
+     * streams. In other words, represents the amount of octets that the H2
+     * endpoint is willing to receive from the peer. Cannot be lower than
+     * 65535 (the default). *)
+    (* TODO(anmonteiro): validate the default somewhere. *)
+    initial_window_size = Settings.WindowSize.default_initial_window_size
   }
 
 let to_settings

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -231,9 +231,8 @@ let send_streaming_response ~flush_headers_immediately t s response =
     in
     let response_body_buffer = Bigstringaf.create s.body_buffer_size in
     let response_body =
-      Body.create
-        response_body_buffer
-        (Optional_thunk.some (fun () -> Writer.wakeup t.writer))
+      Body.create_writer response_body_buffer ~ready_to_write:(fun () ->
+          Writer.wakeup t.writer)
     in
     Writer.write_response_headers t.writer s.encoder frame_info response;
     if s.wait_for_first_flush then Writer.yield t.writer;

--- a/lib/scheduler.ml
+++ b/lib/scheduler.ml
@@ -294,11 +294,12 @@ module Make (Streamd : StreamDescriptor) = struct
     let stream_id = Streamd.id descriptor in
     StreamsTbl.add root.all_streams stream_id stream;
     root.children <- pq_add stream_id stream root.children;
-    match priority with
+    (match priority with
     | Some priority ->
       reprioritize_stream t ~priority stream
     | None ->
-      ()
+      ());
+    stream
 
   let get_node (Connection root) stream_id =
     StreamsTbl.find_opt root.all_streams stream_id
@@ -317,7 +318,7 @@ module Make (Streamd : StreamDescriptor) = struct
     root.flow > 0 && stream.flow > 0
 
   let allowed_to_receive (Connection root) (Stream stream) size =
-    size < root.inflow && size < stream.inflow
+    size <= root.inflow && size <= stream.inflow
 
   let write (Connection root as t) stream_node =
     let (Stream ({ descriptor; _ } as stream)) = stream_node in

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -646,11 +646,6 @@ let process_data_frame t { Frame.frame_header; _ } bstr =
             set_error_and_handle t descriptor `Bad_request ProtocolError
           | _ ->
             let end_stream = Flags.test_end_stream flags in
-            (* XXX(anmonteiro): should we only give back flow control after we
-             * delivered EOF to the request body? There's a potential flow
-             * control issue right now where we're handing out connection-level
-             * flow control tokens on the receipt of every DATA frame. This
-             * might allow clients to send an unbounded number of bytes. *)
             if end_stream then
               if
                 (* From RFC7540§6.1:

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -177,6 +177,29 @@ let on_close_stream t id ~active closed =
     t.current_client_streams <- t.current_client_streams - 1;
   Scheduler.mark_for_removal t.streams id closed
 
+let send_window_update
+    : type a. t -> a Scheduler.PriorityTreeNode.node -> int -> unit
+  =
+ fun t stream n ->
+  let send_window_update_frame stream_id n =
+    let valid_inflow = Scheduler.add_inflow stream n in
+    assert valid_inflow;
+    let frame_info = Writer.make_frame_info stream_id in
+    Writer.write_window_update t.writer frame_info n
+  in
+  if n > 0 then (
+    let max_window_size = Settings.WindowSize.max_window_size in
+    let stream_id = Scheduler.stream_id stream in
+    let rec loop n =
+      if n > max_window_size then (
+        send_window_update_frame stream_id max_window_size;
+        loop (n - max_window_size))
+      else
+        send_window_update_frame stream_id n
+    in
+    loop n;
+    wakeup_writer t)
+
 let create_push_stream ({ max_pushed_stream_id; _ } as t) () =
   if not t.settings.enable_push then
     (* From RFC7540§6.6:
@@ -205,14 +228,17 @@ let create_push_stream ({ max_pushed_stream_id; _ } as t) () =
         t.error_handler
         (on_close_stream t pushed_stream_id)
     in
-    Scheduler.add
-      t.streams (* TODO: *)
-                (* ?priority *)
-      ~initial_window_size:t.settings.initial_window_size
-      reqd;
+    let _stream =
+      Scheduler.add
+        t.streams (* TODO: *)
+                  (* ?priority *)
+        ~initial_window_size:t.settings.initial_window_size
+        reqd
+    in
     Ok reqd
 
-let handle_headers t ~end_stream reqd active_stream headers =
+let handle_headers t ~end_stream stream active_stream headers =
+  let (Scheduler.Stream { descriptor = reqd; _ }) = stream in
   (* From RFC7540§5.1.2:
    *   Endpoints MUST NOT exceed the limit set by their peer. An endpoint that
    *   receives a HEADERS frame that causes its advertised concurrent stream
@@ -273,9 +299,20 @@ let handle_headers t ~end_stream reqd active_stream headers =
                  * value for [request_body_buffer_size]. *)
                 t.config.request_body_buffer_size
             in
-            Body.create
+            Body.create_reader
               (Bigstringaf.create buffer_size)
-              (Optional_thunk.some (fun () -> Writer.wakeup t.writer))
+              ~done_reading:(fun len ->
+                (* From RFC7540§6.9.1:
+                 *   The receiver of a frame sends a WINDOW_UPDATE frame as it
+                 *   consumes data and frees up space in flow-control windows.
+                 *   Separate WINDOW_UPDATE frames are sent for the stream- and
+                 *   connection-level flow-control windows. *)
+                match reqd.state with
+                | Active _ ->
+                  send_window_update t t.streams len;
+                  send_window_update t stream len
+                | Idle | Reserved _ | Closed _ ->
+                  ())
         in
         let request_info = Reqd.create_active_request request request_body in
         if end_stream then (
@@ -294,13 +331,14 @@ let handle_headers t ~end_stream reqd active_stream headers =
 let handle_headers_block
     t
     ?(is_trailers = false)
-    reqd
+    stream
     active_stream
     partial_headers
     flags
     headers_block
   =
   let open AB in
+  let (Scheduler.Stream { descriptor = reqd; _ }) = stream in
   let end_headers = Flags.test_end_header flags in
   (* From RFC7540§6.10:
    *   An endpoint receiving HEADERS, PUSH_PROMISE, or CONTINUATION
@@ -332,7 +370,7 @@ let handle_headers_block
         handle_headers
           t
           ~end_stream:partial_headers.end_stream
-          reqd
+          stream
           active_stream
           headers)
       else if Headers.trailers_valid headers then (
@@ -386,13 +424,15 @@ let open_stream t ?priority stream_id =
           t.error_handler
           (on_close_stream t stream_id)
       in
-      Scheduler.add
-        t.streams
-        ?priority
-        ~initial_window_size:t.settings.initial_window_size
-        reqd;
-      Some reqd
-    | Some (Scheduler.Stream stream) ->
+      let stream =
+        Scheduler.add
+          t.streams
+          ?priority
+          ~initial_window_size:t.settings.initial_window_size
+          reqd
+      in
+      Some stream
+    | Some (Scheduler.Stream node as stream) ->
       (* From RFC7540§6.9.2:
        *   Both endpoints can adjust the initial window size for new streams
        *   by including a value for SETTINGS_INITIAL_WINDOW_SIZE in the
@@ -401,10 +441,11 @@ let open_stream t ?priority stream_id =
        * Note: we already have the stream in the priority tree, and the
        * default initial window size for new streams could have changed
        * between adding the (idle) stream and opening it. *)
-      stream.flow <- t.settings.initial_window_size;
-      Some stream.descriptor
+      node.flow <- t.settings.initial_window_size;
+      Some stream
 
-let process_first_headers_block t frame_header reqd headers_block =
+let process_first_headers_block t frame_header stream headers_block =
+  let (Scheduler.Stream { descriptor = reqd; _ }) = stream in
   let { Frame.stream_id; flags; _ } = frame_header in
   let end_headers = Flags.test_end_header flags in
   let headers_block_length = Bigstringaf.length headers_block in
@@ -434,9 +475,16 @@ let process_first_headers_block t frame_header reqd headers_block =
     Active (Open (PartialHeaders partial_headers), active_stream);
   if not end_headers then
     t.receiving_headers_for_stream <- Some stream_id;
-  handle_headers_block t reqd active_stream partial_headers flags headers_block
+  handle_headers_block
+    t
+    stream
+    active_stream
+    partial_headers
+    flags
+    headers_block
 
-let process_trailer_headers t reqd active_stream frame_header headers_block =
+let process_trailer_headers t stream active_stream frame_header headers_block =
+  let (Scheduler.Stream { descriptor = reqd; _ }) = stream in
   let { Frame.stream_id; flags; _ } = frame_header in
   let end_stream = Flags.test_end_stream flags in
   if not end_stream then
@@ -461,7 +509,7 @@ let process_trailer_headers t reqd active_stream frame_header headers_block =
     (* trailer headers: RFC7230§4.4 *)
     handle_trailer_headers
       t
-      reqd
+      stream
       active_stream
       partial_headers
       flags
@@ -485,14 +533,14 @@ let process_headers_frame t { Frame.frame_header; _ } ?priority headers_block =
        *   stream error (Section 5.4.2) of type PROTOCOL_ERROR. *)
       report_stream_error t stream_id Error_code.ProtocolError
     | _ ->
-      (match Scheduler.find t.streams stream_id with
+      (match Scheduler.get_node t.streams stream_id with
       | None ->
         (match open_stream t ?priority stream_id with
         | Some reqd ->
           process_first_headers_block t frame_header reqd headers_block
         | None ->
           ())
-      | Some reqd ->
+      | Some (Scheduler.Stream { descriptor = reqd; _ } as stream) ->
         (match reqd.state with
         | Idle ->
           (* From RFC7540§6.2:
@@ -512,7 +560,7 @@ let process_headers_frame t { Frame.frame_header; _ } ?priority headers_block =
         | Active (Open (FullHeaders | ActiveMessage _), active_stream) ->
           process_trailer_headers
             t
-            reqd
+            stream
             active_stream
             frame_header
             headers_block
@@ -539,29 +587,6 @@ let process_headers_frame t { Frame.frame_header; _ } ?priority headers_block =
            *   a frame with the END_STREAM flag set MUST treat that as a
            *   connection error (Section 5.4.1) of type STREAM_CLOSED [...]. *)
           report_connection_error t Error_code.StreamClosed))
-
-let send_window_update
-    : type a. t -> a Scheduler.PriorityTreeNode.node -> int -> unit
-  =
- fun t stream n ->
-  let send_window_update_frame stream_id n =
-    let valid_inflow = Scheduler.add_inflow stream n in
-    assert valid_inflow;
-    let frame_info = Writer.make_frame_info stream_id in
-    Writer.write_window_update t.writer frame_info n
-  in
-  if n > 0 then (
-    let max_window_size = Settings.WindowSize.max_window_size in
-    let stream_id = Scheduler.stream_id stream in
-    let rec loop n =
-      if n > max_window_size then (
-        send_window_update_frame stream_id max_window_size;
-        loop (n - max_window_size))
-      else
-        send_window_update_frame stream_id n
-    in
-    loop n;
-    wakeup_writer t)
 
 let process_data_frame t { Frame.frame_header; _ } bstr =
   let open Scheduler in
@@ -641,9 +666,11 @@ let process_data_frame t { Frame.frame_header; _ } bstr =
              *   The receiver of a frame sends a WINDOW_UPDATE frame as it
              *   consumes data and frees up space in flow-control windows.
              *   Separate WINDOW_UPDATE frames are sent for the stream- and
-             *   connection-level flow-control windows. *)
-            send_window_update t t.streams payload_length;
-            send_window_update t stream payload_length;
+             *   connection-level flow-control windows.
+             *
+             * Note: we send these WINDOW_UPDATE frames once the body bytes
+             * have been surfaced to the application. This is done in the
+             * record field `done_reading` of `Body.t`. *)
             let faraday = Body.unsafe_faraday request_body in
             if not (Faraday.is_closed faraday) then (
               Faraday.schedule_bigstring faraday bstr;
@@ -728,11 +755,14 @@ let process_priority_frame t { Frame.frame_header; _ } priority =
             t.error_handler
             (on_close_stream t stream_id)
         in
-        Scheduler.add
-          t.streams
-          ~priority
-          ~initial_window_size:t.settings.initial_window_size
-          reqd
+        let _stream =
+          Scheduler.add
+            t.streams
+            ~priority
+            ~initial_window_size:t.settings.initial_window_size
+            reqd
+        in
+        ()
 
 let process_rst_stream_frame t { Frame.frame_header; _ } error_code =
   let { Frame.stream_id; _ } = frame_header in
@@ -1024,9 +1054,9 @@ let process_continuation_frame t { Frame.frame_header; _ } headers_block =
      *   type PROTOCOL_ERROR. *)
     report_connection_error t Error_code.ProtocolError
   else
-    match Scheduler.find t.streams stream_id with
-    | Some stream ->
-      (match stream.state with
+    match Scheduler.get_node t.streams stream_id with
+    | Some (Stream { descriptor; _ } as stream) ->
+      (match descriptor.state with
       | Active (Open (PartialHeaders partial_headers), active_stream) ->
         handle_headers_block
           t
@@ -1205,7 +1235,7 @@ let handle_h2c_request t headers request_body_iovecs =
    *   identifier of 1 (see Section 5.1.1) with default priority values
    *   (Section 5.3.5). *)
   match open_stream t 1l with
-  | Some reqd ->
+  | Some (Stream { descriptor = reqd; _ } as stream) ->
     let active_stream =
       Reqd.create_active_stream
         t.hpack_encoder
@@ -1215,7 +1245,7 @@ let handle_h2c_request t headers request_body_iovecs =
     t.max_client_stream_id <- reqd.Stream.id;
     let lengthv = Httpaf.IOVec.lengthv request_body_iovecs in
     let end_stream = lengthv = 0 in
-    handle_headers t ~end_stream reqd active_stream headers;
+    handle_headers t ~end_stream stream active_stream headers;
     let request = Reqd.request reqd in
     let request_body = Reqd.request_body reqd in
     let request_info = Reqd.create_active_request request request_body in

--- a/lib/settings.ml
+++ b/lib/settings.ml
@@ -167,7 +167,8 @@ type t =
   { header_table_size : int
   ; enable_push : bool
   ; max_concurrent_streams : int
-  ; initial_window_size : int
+  ; (* Indicates the amount tokens the peer allows an H2 endpoint to send. *)
+    initial_window_size : int
   ; max_frame_size : int
   ; max_header_list_size : int option
   }

--- a/lib_test/test_h2_client.ml
+++ b/lib_test/test_h2_client.ml
@@ -1035,17 +1035,6 @@ module Client_connection_tests = struct
     (* Send the rest of the request body. *)
     Body.write_string request_body "hello";
     Body.close_writer request_body;
-    let frames, lenv = flush_pending_writes t in
-    Alcotest.(check (list int))
-      "Only writes are WINDOW_UPDATE frames"
-      (List.map
-         Frame.FrameType.serialize
-         Frame.FrameType.[ WindowUpdate; WindowUpdate ])
-      (List.map
-         (fun Frame.{ frame_header = { frame_type; _ }; _ } ->
-           Frame.FrameType.serialize frame_type)
-         frames);
-    report_write_result t (`Ok lenv);
     writer_yielded t
 
   let test_connection_shutdown () =
@@ -1152,6 +1141,46 @@ module Client_connection_tests = struct
       true
       !body_eof_called
 
+  let test_flow_control () =
+    let t = create_and_handle_preface () in
+    let request = Request.create ~scheme:"http" `GET "/" in
+    let body_read_called = ref false in
+    let response_handler _response response_body =
+      Body.schedule_read
+        response_body
+        ~on_eof:ignore
+        ~on_read:(fun _bs ~off:_ ~len:_ -> body_read_called := true)
+    in
+    let request_body =
+      Client_connection.request
+        t
+        request
+        ~error_handler:default_error_handler
+        ~response_handler
+    in
+    flush_request t;
+    Body.close_writer request_body;
+    flush_request t;
+    let hpack_encoder = Hpack.Encoder.create 4096 in
+    read_response
+      t
+      hpack_encoder
+      ~flags:Flags.(default_flags |> set_end_header)
+      (Response.create `OK ~headers:(Headers.of_list [ "content-length", "3" ]));
+    read_response_body t "foo";
+    let frames, lenv = flush_pending_writes t in
+    Alcotest.(check (list int))
+      "Only writes are WINDOW_UPDATE frames"
+      (List.map
+         Frame.FrameType.serialize
+         Frame.FrameType.[ WindowUpdate; WindowUpdate ])
+      (List.map
+         (fun Frame.{ frame_header = { frame_type; _ }; _ } ->
+           Frame.FrameType.serialize frame_type)
+         frames);
+    report_write_result t (`Ok lenv);
+    Alcotest.(check bool) "Response handler called" true !body_read_called
+
   let suite =
     [ "initial reader state", `Quick, test_initial_reader_state
     ; "set up client connection", `Quick, test_set_up_connection
@@ -1186,11 +1215,14 @@ module Client_connection_tests = struct
     ; ( "request, server sends RST_STREAM with NO_ERROR"
       , `Quick
       , test_request_rst_stream_no_error )
-    ; ( "request, server sends RST_STREAM with NO_ERROR"
+    ; ( "request, server sends RST_STREAM with NO_ERROR, has request body"
       , `Quick
       , test_request_body_rst_stream_no_error )
     ; "test connection shutdown", `Quick, test_connection_shutdown
-    ; "test reading the response body", `Quick, test_reading_response_body
+    ; ( "reading the response body as it arrives"
+      , `Quick
+      , test_reading_response_body )
+    ; "flow control", `Quick, test_flow_control
     ]
 end
 

--- a/lib_test/test_priority.ml
+++ b/lib_test/test_priority.ml
@@ -55,11 +55,12 @@ let repeat (Scheduler.PriorityTreeNode.Connection root) queue num =
   loop queue num []
 
 let add_stream root ?priority reqd =
-  Scheduler.add
-    root
-    ?priority
-    ~initial_window_size:Settings.WindowSize.default_initial_window_size
-    reqd
+  ignore
+  @@ Scheduler.add
+       root
+       ?priority
+       ~initial_window_size:Settings.WindowSize.default_initial_window_size
+       reqd
 
 let test_priority_queue () =
   let root = Scheduler.make_root ~capacity:1000 () in

--- a/lib_test/test_priority.ml
+++ b/lib_test/test_priority.ml
@@ -59,7 +59,8 @@ let add_stream root ?priority reqd =
   @@ Scheduler.add
        root
        ?priority
-       ~initial_window_size:Settings.WindowSize.default_initial_window_size
+       ~initial_recv_window_size:Settings.WindowSize.default_initial_window_size
+       ~initial_send_window_size:Settings.WindowSize.default_initial_window_size
        reqd
 
 let test_priority_queue () =


### PR DESCRIPTION
This diff implements proper flow control in h2, whereas previously the endpoint would just give back flow control tokens to the peer upon the receipt of `DATA` frames.