### PR TITLE
Handle frame size errors in a more robust manner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Unreleased
   ([#132](https://github.com/anmonteiro/ocaml-h2/pull/132))
 - h2: don't attempt to write frames to an encoder that has closed
   ([#134](https://github.com/anmonteiro/ocaml-h2/pull/134))
+- h2: Handle frame size errors in a more robust manner when parsing
+  ([#133](https://github.com/anmonteiro/ocaml-h2/pull/133))
 
 0.6.1 2020-05-16
 ---------------

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -1233,7 +1233,11 @@ let create ?(config = Config.default) ?push_handler ~error_handler =
       ; pending_pings = Queue.create ()
       ; error_handler
       ; push_handler
-      ; reader = Reader.client_frames connection_preface_handler frame_handler
+      ; reader =
+          Reader.client_frames
+            ~max_frame_size:settings.max_frame_size
+            connection_preface_handler
+            frame_handler
       ; writer = Writer.create settings.max_frame_size
       ; streams =
           Scheduler.make_root ()

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -1211,7 +1211,11 @@ let create_generic ~h2c ~config ~error_handler request_handler =
   and t =
     lazy
       { settings
-      ; reader = Reader.server_frames connection_preface_handler frame_handler
+      ; reader =
+          Reader.server_frames
+            ~max_frame_size:settings.max_frame_size
+            connection_preface_handler
+            frame_handler
       ; writer
       ; config
       ; request_handler

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -105,7 +105,12 @@ let parse_frames_bigstring wire =
     | _ ->
       Alcotest.fail "Expected frame to parse successfully."
   in
-  let reader = Reader.server_frames (fun _ -> ignore) handler in
+  let reader =
+    Reader.server_frames
+      ~max_frame_size:H2.Settings.default.max_frame_size
+      (fun _ -> ignore)
+      handler
+  in
   handle_preface reader;
   let _read =
     Reader.read_with_more

--- a/lib_test/test_frames.ml
+++ b/lib_test/test_frames.ml
@@ -33,7 +33,12 @@ module P = struct
       | Error e ->
         error_handler e
     in
-    let reader = Reader.server_frames (fun _ -> ignore) handler in
+    let reader =
+      Reader.server_frames
+        ~max_frame_size:Settings.default.max_frame_size
+        (fun _ -> ignore)
+        handler
+    in
     handle_preface reader;
     let wire_bs = wire |> string_of_hex |> bs_of_string in
     let _read =

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/70347e97.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/db63c40.tar.gz;
 
 in
 


### PR DESCRIPTION
Rely on the configured `max_frame_size` instead of checking the
length of the bigstring, as that doesn't work with `sub` views into
bigarrays.