### PR TITLE
add Reqd.schedule_trailers (fixes #97)

### DIFF
--- a/lib/h2.mli
+++ b/lib/h2.mli
@@ -502,7 +502,13 @@ module Reqd : sig
     -> Response.t
     -> [ `write ] Body.t
 
-  val send_trailers_on_close : t -> Headers.t -> unit
+  val schedule_trailers : t -> Headers.t -> unit
+  (** [schedule_trailers reqd trailers] schedules a list of trailers to be sent
+      before the stream is closed, concluding the HTTP message. Should only be
+      used after {!respond_with_streaming}. Raises [Failure] if trailers have
+      already been scheduled. See
+      {{:https://tools.ietf.org/html/rfc7540#section-8.1} RFC7540§8.1} for more
+      information *)
 
   (** {3 Pushing}
 

--- a/lib/h2.mli
+++ b/lib/h2.mli
@@ -502,6 +502,8 @@ module Reqd : sig
     -> Response.t
     -> [ `write ] Body.t
 
+  val send_trailers_on_close : t -> Headers.t -> unit
+
   (** {3 Pushing}
 
       HTTP/2 allows a server to pre-emptively send (or "push") responses (along

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -51,7 +51,7 @@ type response_state =
       ; mutable iovec :
           [ `String of string | `Bigstring of Bigstringaf.t ] Httpaf.IOVec.t
       }
-  | Streaming of Response.t * [ `write ] Body.t
+  | Streaming of Response.t * [ `write ] Body.t * Headers.t option
   | Complete of Response.t
 
 type request_info =
@@ -131,7 +131,7 @@ let response t =
     (match response_state with
     | Waiting ->
       None
-    | Streaming (response, _) | Fixed { response; _ } | Complete response ->
+    | Streaming (response, _, _) | Fixed { response; _ } | Complete response ->
       Some response)
   | Closed _ ->
     None
@@ -147,7 +147,7 @@ let response_exn t =
     (match response_state with
     | Waiting ->
       failwith "h2.Reqd.response_exn: response has not started"
-    | Streaming (response, _) | Fixed { response; _ } | Complete response ->
+    | Streaming (response, _, _) | Fixed { response; _ } | Complete response ->
       response)
   | Closed _ ->
     assert false
@@ -192,6 +192,30 @@ let send_fixed_response t s response data =
   | Fixed _ | Complete _ ->
     failwith "h2.Reqd.respond_with_*: response already complete"
 
+let send_trailers_on_close t new_trailers =
+  let go s =
+    match s.response_state with
+    | Streaming (rsp, rsp_body, _old_trailers) ->
+      s.response_state <- Streaming (rsp, rsp_body, Some new_trailers)
+    | _ ->
+      failwith
+        "h2.Reqd.send_trailers_on_close: can only send trailers in Streaming \
+         mode"
+  in
+  match t.state with
+  | Idle | Active (Open (WaitingForPeer | PartialHeaders _), _) | Closed _ ->
+    assert false
+  | Active ((Open (FullHeaders | ActiveMessage _) | HalfClosed _), stream) ->
+    go stream
+  | Reserved (request_info, stream) ->
+    go stream;
+    (* From RFC7540§8.1: * reserved (local): [...] In this state, only the
+       following transitions * are possible: The endpoint can send a HEADERS
+       frame. This causes the * stream to open in a "half-closed (remote)"
+       state. *)
+    Writer.flush t.writer (fun () ->
+        t.state <- Active (HalfClosed request_info, stream))
+
 let unsafe_respond_with_data t response data =
   match t.state with
   | Idle | Active (Open (WaitingForPeer | PartialHeaders _), _) ->
@@ -235,7 +259,7 @@ let send_streaming_response ~flush_headers_immediately t s response =
     in
     Writer.write_response_headers t.writer s.encoder frame_info response;
     if wait_for_first_flush then Writer.yield t.writer;
-    s.response_state <- Streaming (response, response_body);
+    s.response_state <- Streaming (response, response_body, None);
     Writer.wakeup t.writer;
     response_body
   | Streaming _ ->
@@ -366,11 +390,11 @@ let _report_error ?request t s exn error_code =
      * outstanding call to the [error_handler], but an intervening exception
      * has been reported as well. *)
     failwith "h2.Reqd.report_exn: NYI"
-  | Streaming (_response, response_body), `Ok ->
+  | Streaming (_response, response_body, _), `Ok ->
     Body.close_writer response_body;
     t.error_code <- (exn :> [ `Ok | error ]), Some error_code;
     reset_stream t error_code
-  | Streaming (_response, response_body), `Exn _ ->
+  | Streaming (_response, response_body, _), `Exn _ ->
     Body.close_writer response_body;
     t.error_code <- fst t.error_code, Some error_code;
     reset_stream t error_code;
@@ -463,7 +487,7 @@ let flush_response_body t ~max_bytes =
   match t.state with
   | Active ((Open _ | HalfClosed _), stream) ->
     (match stream.response_state with
-    | Streaming (response, response_body) ->
+    | Streaming (response, response_body, trailers) ->
       if Body.has_pending_output response_body && max_bytes > 0 then
         Body.transfer_to_writer
           response_body
@@ -474,20 +498,31 @@ let flush_response_body t ~max_bytes =
       else if Body.is_closed response_body then (
         (* no pending output and closed, we can finalize the message and close
            the stream *)
-        let frame_info =
-          Writer.make_frame_info
-            ~max_frame_size:t.max_frame_size
-            ~flags:Flags.(set_end_stream default_flags)
-            t.id
+        let frame_info flags =
+          Writer.make_frame_info ~max_frame_size:t.max_frame_size ~flags t.id
         in
-        (* From RFC7540§6.9.1:
-         *   Frames with zero length with the END_STREAM flag set (that is, an
-         *   empty DATA frame) MAY be sent if there is no available space in
-         *   either flow-control window. *)
-        Writer.schedule_data t.writer frame_info ~len:0 Bigstringaf.empty;
-        Writer.flush t.writer (fun () -> close_stream t);
-        stream.response_state <- Complete response;
-        0)
+        let write_zero_frame frame_info =
+          (* From RFC7540§6.9.1:
+           *   Frames with zero length with the END_STREAM flag set (that is, an
+           *   empty DATA frame) MAY be sent if there is no available space in
+           *   either flow-control window. *)
+          Writer.schedule_data t.writer frame_info ~len:0 Bigstringaf.empty
+        in
+        match trailers with
+        | Some trailers ->
+          Writer.write_response_trailers
+            t.writer
+            stream.encoder
+            (frame_info Flags.(set_end_stream default_flags))
+            trailers;
+          close_stream t;
+          stream.response_state <- Complete response;
+          0
+        | None ->
+          write_zero_frame (frame_info Flags.(set_end_stream default_flags));
+          close_stream t;
+          stream.response_state <- Complete response;
+          0)
       else (* no pending output but Body is still open *)
         0
     | Fixed r when max_bytes > 0 ->

--- a/lib_test/test_h2_server.ml
+++ b/lib_test/test_h2_server.ml
@@ -1189,6 +1189,70 @@ module Server_connection_tests = struct
     | _ ->
       assert false
 
+  let trailers_request_handler reqd =
+    let response = Response.create `OK in
+    (* Send the response for / *)
+    let response_body = Reqd.respond_with_streaming reqd response in
+    Body.write_string response_body "somedata";
+    Body.flush response_body (fun () ->
+        Reqd.send_trailers_on_close reqd Headers.(add empty "foo" "bar");
+        Body.close_writer response_body)
+
+  let test_trailers () =
+    let t = create ~error_handler trailers_request_handler in
+    handle_preface t;
+    let headers, _ = header_and_continuation_frames in
+    let headers =
+      { headers with
+        Frame.frame_header =
+          { headers.frame_header with
+            flags = Flags.(default_flags |> set_end_header |> set_end_stream)
+          }
+      }
+    in
+    read_frames t [ headers ];
+    match next_write_operation t with
+    | `Write iovecs ->
+      let frames = parse_frames (Write_operation.iovecs_to_string iovecs) in
+      Alcotest.(check (list int))
+        "Next write operation surfaces writes for HEADERS / DATA"
+        List.(map Frame.FrameType.serialize Frame.FrameType.[ Headers; Data ])
+        List.(
+          map
+            (fun { Frame.frame_header; _ } ->
+              Frame.FrameType.serialize frame_header.frame_type)
+            frames);
+      let iovec_len = IOVec.lengthv iovecs in
+      report_write_result t (`Ok iovec_len);
+      (match next_write_operation t with
+      | `Write iovecs ->
+        let frames = parse_frames (Write_operation.iovecs_to_string iovecs) in
+        let frame = List.hd frames in
+        Alcotest.(check int)
+          "Next write operation surfaces the trailers HEADERS frame"
+          Frame.FrameType.(serialize Headers)
+          Frame.FrameType.(serialize frame.frame_header.frame_type);
+        let iovec_len = IOVec.lengthv iovecs in
+        report_write_result t (`Ok iovec_len);
+        Alcotest.check
+          write_operation
+          "Writer yields"
+          `Yield
+          (next_write_operation t);
+        Alcotest.check
+          read_operation
+          "Reader wants to read"
+          `Read
+          (next_read_operation t)
+      | _ ->
+        Alcotest.fail
+          "Expected state machine to issue a write operation after seeing  (*\n\
+          \       headers.")
+    | _ ->
+      Alcotest.fail
+        "Expected state machine to issue a write operation after seeing \
+         headers."
+
   (* TODO: test for trailer headers. *)
   (* TODO: test graceful shutdown, allowing lower numbered streams to complete. *)
   let suite =
@@ -1246,6 +1310,7 @@ module Server_connection_tests = struct
     ; ( "flow control -- can send empty data frame"
       , `Quick
       , test_flow_control_can_send_empty_data_frame )
+    ; "trailers", `Quick, test_trailers
     ]
 end
 


### PR DESCRIPTION
This PR makes sending trailing headers (aka. trailers) possible, and thus allows H2 to be used to implement gRPC.
I've been going back and forth on the best patch to write, and I believe this strikes a good balance, but I'm curious to hear your thoughts.
I had a look at the changes proposed in #72 and I believe it suffers from the sequencing issue described below (commit #1).
However, I did steal the test case from there.

Commit 1 (move Streaming flush logic out of Body):
- Body.close_writer caused stream to close before we had the chance to send headers
- Body.close_writer caused next flush to send a zero length DATA frame, which leads to a sequence like HEADERS, DATA, TRAILERS, DATA
- imo, Body should not be concerned with HTTP details (knowing about RFC7540 and sending DATA frames)
- moving the corresponding code out of Body and into Reqd feels like the right thing to do since it allows for better sequencing + simpler code (`has_pending_output` forwards to Faraday, no more `t.write_final_data_frame` and no more `response_body_requires_output`)
I also noticed a potential bug where I believe the zero length DATA frame is never sent if we're flow-controlled (maxxed out sent bytes) in `Scheduler.write`

Commit 2 (allow trailing headers, fixes #97)
- straight-forward thanks to the sequencing control allowed by commit 1
- we choose not to let user send trailers directly, but instead register them and later send them on Body.close to avoid user mistakes (sending trailers too early or too late)
- this also allows to avoid sending a useless zero length DATA frame before the trailers

Quick note: I was confused at the beginning as to how the state machine worked, until I realized it relied on Gluten. It's not obvious at first if you're grepping around (could not find `next_write_operation` call sites)
You may want to have a quick blurb or schema showing the `Gluten -> Server_connection -> Scheduler -> Reqd -> Writer -> Faraday` chain.