### PR TITLE
Add trailers_handler to Connection.request

### DIFF
--- a/async/h2_async_intf.ml
+++ b/async/h2_async_intf.ml
@@ -67,6 +67,7 @@ module type Client = sig
 
   val request
     :  t
+    -> ?trailers_handler:Client_connection.trailers_handler
     -> Request.t
     -> error_handler:Client_connection.error_handler
     -> response_handler:Client_connection.response_handler

--- a/lib/h2.mli
+++ b/lib/h2.mli
@@ -806,6 +806,8 @@ module Client_connection : sig
     | `Exn of exn
     ]
 
+  type trailers_handler = Headers.t -> unit
+
   type response_handler = Response.t -> [ `read ] Body.t -> unit
 
   type error_handler = error -> unit
@@ -847,15 +849,17 @@ module Client_connection : sig
 
   val request
     :  t
+    -> ?trailers_handler:trailers_handler
     -> Request.t
     -> error_handler:error_handler
     -> response_handler:response_handler
     -> [ `write ] Body.t
-  (** [request connection req ~error_handler ~response_handler] opens a new
-      HTTP/2 stream with [req] and returns a request body that can be written
-      to. Once a response arrives, [response_handler] will be called with its
-      headers and body. [error_handler] will be called for {e stream-level}
-      errors.
+  (** [request connection ?trailers_handler req ~error_handler
+      ~response_handler] opens a new HTTP/2 stream with [req] and returns a
+      request body that can be written to. Once a response arrives,
+      [response_handler] will be called with its headers and body.
+      [error_handler] will be called for {e stream-level} errors. If there are
+      any trailers they will be parsed and passed to [trailers_handler].
 
       HTTP/2 is multiplexed over a single TCP connection and distinguishes
       connection-level errors from stream-level errors. See

--- a/lwt/h2_lwt_intf.ml
+++ b/lwt/h2_lwt_intf.ml
@@ -67,6 +67,7 @@ module type Client = sig
 
   val request
     :  t
+    -> ?trailers_handler:Client_connection.trailers_handler
     -> Request.t
     -> error_handler:Client_connection.error_handler
     -> response_handler:Client_connection.response_handler


### PR DESCRIPTION
This adds an optional parameter when making a request to handle trailers sent by the server.

I'm not entirely sure on the API for this at the moment, could potentially change it to more of a `schedule_read_trailers` similar to the server but not sure where best to expose that as `Respd` isn't exposed.

Happy for comments and ways to improve this.