### PR TITLE
Fix a security issue where a malicious peer could tell h2 to allocate too much

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ Unreleased
   there were no flow-control credits
   ([#142](https://github.com/anmonteiro/ocaml-h2/pull/142)) -- reported  by
   [@blandinw](https://github.com/blandinw)
+- h2: client / server: fix a security issue that allowed a malicious peer to
+  make h2 allocate as much as it wanted
+  ([#149](https://github.com/anmonteiro/ocaml-h2/pull/149))
 
 0.7.0 2020-08-09
 ---------------

--- a/hpack/test/test.ml
+++ b/hpack/test/test.ml
@@ -314,4 +314,4 @@ let () =
          , `Quick
          , test_evicting_table_size_0_followup )
        ] )
-    :: suites)
+     :: suites)

--- a/hpack/util/gen_static.ml
+++ b/hpack/util/gen_static.ml
@@ -33,10 +33,10 @@ open Parsetree
 open Ast_helper
 open Asttypes
 
+let ghloc = !default_loc
+
 let let_ name body =
-  Str.value
-    Nonrecursive
-    [ Vb.mk (Pat.var { txt = name; loc = !default_loc }) body ]
+  Str.value Nonrecursive [ Vb.mk (Pat.var { txt = name; loc = ghloc }) body ]
 
 module CharSet = Set.Make (Char)
 
@@ -116,8 +116,8 @@ let mk_static_table static_table =
       (fun acc (_, name, value) ->
         let tup =
           Exp.tuple
-            [ Exp.constant (Pconst_string (name, None))
-            ; Exp.constant (Pconst_string (value, None))
+            [ Exp.constant (Pconst_string (name, ghloc, None))
+            ; Exp.constant (Pconst_string (value, ghloc, None))
             ]
         in
         tup :: acc)
@@ -180,7 +180,8 @@ let mk_lookup_token token_map =
                                               } )
                                         ; ( Nolabel
                                           , Exp.constant
-                                              (Pconst_string (name, None)) )
+                                              (Pconst_string (name, ghloc, None))
+                                          )
                                         ])
                                    (Exp.constant
                                       (Pconst_integer (string_of_int i, None))))

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -302,17 +302,8 @@ let handle_response_headers t stream ~end_stream active_request headers =
         if end_stream then
           Body.empty
         else
-          let buffer_size =
-            match body_length with
-            | `Fixed n ->
-              Int64.to_int n
-            | `Error _ | `Unknown ->
-              (* Not sure how much data we're gonna get. Use the configured
-               * value for [response_body_buffer_size]. *)
-              t.config.response_body_buffer_size
-          in
           Body.create_reader
-            (Bigstringaf.create buffer_size)
+            (Bigstringaf.create t.config.response_body_buffer_size)
             ~done_reading:(fun len ->
               send_window_update t t.streams len;
               send_window_update t stream len)

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -297,7 +297,7 @@ let handle_response_headers t stream ~end_stream active_request headers =
         respd
         (`Invalid_response_body_length response)
         ProtocolError
-    | body_length ->
+    | `Fixed _ | `Unknown ->
       let response_body =
         if end_stream then
           Body.empty

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -298,17 +298,8 @@ let handle_headers t ~end_stream stream active_stream headers =
           if end_stream then
             Body.empty
           else
-            let buffer_size =
-              match body_length with
-              | `Fixed n ->
-                Int64.to_int n
-              | `Error _ | `Unknown ->
-                (* Not sure how much data we're gonna get. Use the configured
-                 * value for [request_body_buffer_size]. *)
-                t.config.request_body_buffer_size
-            in
             Body.create_reader
-              (Bigstringaf.create buffer_size)
+              (Bigstringaf.create t.config.request_body_buffer_size)
               ~done_reading:(fun len ->
                 (* From RFC7540§6.9.1:
                  *   The receiver of a frame sends a WINDOW_UPDATE frame as it

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -290,7 +290,7 @@ let handle_headers t ~end_stream stream active_stream headers =
       (match Message.body_length headers with
       | `Error e ->
         set_error_and_handle t reqd e ProtocolError
-      | body_length ->
+      | `Fixed _ | `Unknown ->
         let request =
           Request.create ~scheme ~headers (Httpaf.Method.of_string meth) path
         in

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,5 +1,5 @@
 { pkgs ? import ./sources.nix { inherit ocamlVersion; }
-, ocamlVersion ? "4_10"
+, ocamlVersion ? "4_12"
 , doCheck ? true }:
 
 let

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,41 +1,41 @@
-{ ocamlVersion ? "4_11" }:
+{ ocamlVersion ? "4_12" }:
 
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/1718c8f.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/44d71c6a.tar.gz;
 
 in
 
-  import "${overlays}/sources.nix" {
-    overlays = [
-      (import overlays)
-      (self: super: {
-        ocamlPackages = super.ocaml-ng."ocamlPackages_${ocamlVersion}".overrideScope'
-            (super.callPackage "${overlays}/ocaml" {});
+import "${overlays}/sources.nix" {
+  overlays = [
+    (import overlays)
+    (self: super: {
+      ocamlPackages = super.ocaml-ng."ocamlPackages_${ocamlVersion}".overrideScope'
+        (super.callPackage "${overlays}/ocaml" { });
 
-        h2spec = super.stdenv.mkDerivation rec {
-          name = "h2spec";
-          version = "2.6.0";
-          src = builtins.fetchurl (if super.stdenv.isDarwin then {
-            url = "https://github.com/summerwind/h2spec/releases/download/v${version}/h2spec_darwin_amd64.tar.gz";
-            sha256 = "008ngmlmj4slm13a2qvdyvfd6f3lxga2n0k300q3cpkg1bwvj74q";
-          } else {
-            url = "https://github.com/summerwind/h2spec/releases/download/v${version}/h2spec_linux_amd64.tar.gz";
-            sha256 = "064k4yg818hd8pwh8xcf1iapw0k6ndsg1nsjwx0as09ff3gf0zhm";
-          });
-          phases = ["unpackPhase" "installPhase" "fixupPhase"];
-          nativeBuildInputs = (if super.stdenv.isDarwin then [] else [ self.autoPatchelfHook ]);
-          unpackPhase = ''
-            mkdir h2spec-${version}
-            tar -C h2spec-${version} -xzf $src
-          '';
-          installPhase = ''
-            mkdir -p $out/bin
-            cp h2spec-${version}/* $out/bin
-            chmod +x $out/bin/h2spec
-          '';
-        };
-      })
-    ];
-  }
+      h2spec = super.stdenv.mkDerivation rec {
+        name = "h2spec";
+        version = "2.6.0";
+        src = builtins.fetchurl (if super.stdenv.isDarwin then {
+          url = "https://github.com/summerwind/h2spec/releases/download/v${version}/h2spec_darwin_amd64.tar.gz";
+          sha256 = "008ngmlmj4slm13a2qvdyvfd6f3lxga2n0k300q3cpkg1bwvj74q";
+        } else {
+          url = "https://github.com/summerwind/h2spec/releases/download/v${version}/h2spec_linux_amd64.tar.gz";
+          sha256 = "064k4yg818hd8pwh8xcf1iapw0k6ndsg1nsjwx0as09ff3gf0zhm";
+        });
+        phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+        nativeBuildInputs = (if super.stdenv.isDarwin then [ ] else [ self.autoPatchelfHook ]);
+        unpackPhase = ''
+          mkdir h2spec-${version}
+          tar -C h2spec-${version} -xzf $src
+        '';
+        installPhase = ''
+          mkdir -p $out/bin
+          cp h2spec-${version}/* $out/bin
+          chmod +x $out/bin/h2spec
+        '';
+      };
+    })
+  ];
+}


### PR DESCRIPTION
- We were allocating a read body that is the size specified in the `content-length` header
- This could allow a malicious peer to send a giant `content-length` value, and we'd happily try to allocate it
- The fix is to to allocate what we have configured through `t.config.{request,response}_body_buffer_size`