### PR TITLE
Finish client stream after trailer headers

### DIFF
--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -544,7 +544,8 @@ let process_headers_frame t { Frame.frame_header; _ } headers_block =
         stream
         active_response
         frame_header
-        headers_block
+        headers_block;
+      Stream.finish_stream descriptor Finished
     | Closed { reason = ResetByThem _; _ } ->
       (* From RFC7540§5.1:
        *   closed: [...] An endpoint that receives any frame other than


### PR DESCRIPTION
I noticed a memory leak which occurs in the following setting:
- one long-running client connection
- multiple streams that share this connection (sequentially or in parallel)
The memory is only freed when the connection is closed.

It seems to come down to the client streams not being "finished" after receiving trailing headers.

I benchmarked with `Memtrace` and with this change, memory consumption is now stable.