### PR TITLE
Split Body.t into Body.Writer.t and Body.Reader.t

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ Unreleased
   be scheduled and batch `HEADERS` and `DATA` frames when sending requests
   ([#163](https://github.com/anmonteiro/ocaml-h2/pull/163),
   [#164](https://github.com/anmonteiro/ocaml-h2/pull/164))
+- h2: Split `Body.t` into `Body.Writer.t` and `Body.Reader.t`
+  ([#165](https://github.com/anmonteiro/ocaml-h2/pull/165))
 
 0.8.0 2021-04-11
 ---------------

--- a/async/h2_async_intf.ml
+++ b/async/h2_async_intf.ml
@@ -72,7 +72,7 @@ module type Client = sig
     -> Request.t
     -> error_handler:Client_connection.error_handler
     -> response_handler:Client_connection.response_handler
-    -> [ `write ] Body.t
+    -> Body.Writer.t
 
   val ping : t -> ?payload:Bigstringaf.t -> ?off:int -> (unit -> unit) -> unit
 

--- a/examples/alpn/lib/h2_handler.ml
+++ b/examples/alpn/lib/h2_handler.ml
@@ -22,8 +22,8 @@ let request_handler : Unix.sockaddr -> Reqd.t -> unit =
 
 let error_handler
     :  Unix.sockaddr -> ?request:H2.Request.t -> _
-    -> (Headers.t -> [ `write ] Body.t) -> unit
+    -> (Headers.t -> Body.Writer.t) -> unit
   =
  fun _client_address ?request:_ _error start_response ->
   let response_body = start_response Headers.empty in
-  Body.close_writer response_body
+  Body.Writer.close response_body

--- a/examples/lwt/lwt_echo_server2.ml
+++ b/examples/lwt/lwt_echo_server2.ml
@@ -28,7 +28,7 @@ let connection_handler : Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t =
           "application/octet-stream"
       in
       let rec respond () =
-        Body.schedule_read
+        Body.Reader.schedule_read
           request_body
           ~on_eof:(fun () ->
             let response =
@@ -62,19 +62,19 @@ let connection_handler : Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t =
         Reqd.respond_with_streaming request_descriptor response
       in
       let rec respond () =
-        Body.schedule_read
+        Body.Reader.schedule_read
           request_body
           ~on_eof:(fun () ->
             set_interval
               1
               (fun () ->
-                Body.write_string response_body "FOO";
+                Body.Writer.write_string response_body "FOO";
                 (* Body.flush response_body ignore; *)
                 true)
               (* Body.flush response_body ignore; *)
-                (fun () -> Body.close_writer response_body))
+                (fun () -> Body.Writer.close response_body))
           ~on_read:(fun request_data ~off ~len ->
-            Body.write_bigstring response_body request_data ~off ~len;
+            Body.Writer.write_bigstring response_body request_data ~off ~len;
             respond ())
       in
       respond ()
@@ -90,20 +90,25 @@ let connection_handler : Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t =
       in
       (* let (finished, notify) = Lwt.wait () in *)
       let rec on_read _request_data ~off:_ ~len:_ =
-        Body.flush response_body (fun () ->
-            Body.schedule_read request_body ~on_eof ~on_read)
+        Body.Writer.flush response_body (fun () ->
+            Body.Reader.schedule_read request_body ~on_eof ~on_read)
       and on_eof () =
         set_interval
           2
           (fun () ->
-            let _ = Body.write_string response_body "data: some data\n\n" in
-            Body.flush response_body (fun () -> ());
+            let _ =
+              Body.Writer.write_string response_body "data: some data\n\n"
+            in
+            Body.Writer.flush response_body (fun () -> ());
             true)
           (fun () ->
-            let _ = Body.write_string response_body "event: end\ndata: 1\n\n" in
-            Body.flush response_body (fun () -> Body.close_writer response_body))
+            let _ =
+              Body.Writer.write_string response_body "event: end\ndata: 1\n\n"
+            in
+            Body.Writer.flush response_body (fun () ->
+                Body.Writer.close response_body))
       in
-      Body.schedule_read ~on_read ~on_eof request_body;
+      Body.Reader.schedule_read ~on_read ~on_eof request_body;
       ()
     | _ ->
       Reqd.respond_with_string
@@ -113,17 +118,19 @@ let connection_handler : Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t =
   in
   let error_handler
       :  Unix.sockaddr -> ?request:H2.Request.t -> _
-      -> (Headers.t -> [ `write ] Body.t) -> unit
+      -> (Headers.t -> Body.Writer.t) -> unit
     =
    fun _client_address ?request:_ error start_response ->
     let response_body = start_response Headers.empty in
     (match error with
     | `Exn exn ->
-      Body.write_string response_body (Printexc.to_string exn);
-      Body.write_string response_body "\n"
+      Body.Writer.write_string response_body (Printexc.to_string exn);
+      Body.Writer.write_string response_body "\n"
     | #Status.standard as error ->
-      Body.write_string response_body (Status.default_reason_phrase error));
-    Body.close_writer response_body
+      Body.Writer.write_string
+        response_body
+        (Status.default_reason_phrase error));
+    Body.Writer.close response_body
   in
   H2_lwt_unix.Server.create_connection_handler
     ?config:None

--- a/examples/lwt/lwt_get.ml
+++ b/examples/lwt/lwt_get.ml
@@ -3,7 +3,7 @@ module Client = H2_lwt_unix.Client
 
 let response_handler notify_response_received _response response_body =
   let rec read_response () =
-    Body.schedule_read
+    Body.Reader.schedule_read
       response_body
       ~on_eof:(fun () -> Lwt.wakeup_later notify_response_received ())
       ~on_read:(fun bigstring ~off ~len ->
@@ -59,5 +59,5 @@ let () =
       let request_body =
         Client.SSL.request connection request ~error_handler ~response_handler
       in
-      Body.close_writer request_body;
+      Body.Writer.close request_body;
       response_received )

--- a/examples/lwt/lwt_h2c.ml
+++ b/examples/lwt/lwt_h2c.ml
@@ -24,7 +24,7 @@ module Http2 = struct
         in
         let buf = Buffer.create 10 in
         let rec respond () =
-          Body.schedule_read
+          Body.Reader.schedule_read
             request_body
             ~on_eof:(fun () ->
               let response =
@@ -59,11 +59,13 @@ module Http2 = struct
       let response_body = start_response Headers.empty in
       (match error with
       | `Exn exn ->
-        Body.write_string response_body (Printexc.to_string exn);
-        Body.write_string response_body "\n"
+        Body.Writer.write_string response_body (Printexc.to_string exn);
+        Body.Writer.write_string response_body "\n"
       | #Status.standard as error ->
-        Body.write_string response_body (Status.default_reason_phrase error));
-      Body.close_writer response_body
+        Body.Writer.write_string
+          response_body
+          (Status.default_reason_phrase error));
+      Body.Writer.close response_body
     in
     fun http_request request_body ->
       H2.Server_connection.create_h2c

--- a/examples/lwt/lwt_https_server.ml
+++ b/examples/lwt/lwt_https_server.ml
@@ -81,7 +81,7 @@ let connection_handler : Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t =
   in
   let error_handler
       :  Unix.sockaddr -> ?request:H2.Request.t -> _
-      -> (Headers.t -> [ `write ] Body.t) -> unit
+      -> (Headers.t -> Body.Writer.t) -> unit
     =
    fun _client_address ?request:_ _error start_response ->
     let response_body = start_response Headers.empty in
@@ -90,7 +90,7 @@ let connection_handler : Unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t =
 
        | #Status.standard as error -> Body.write_string response_body
        (Status.default_reason_phrase error) end; *)
-    Body.close_writer response_body
+    Body.Writer.close response_body
   in
   let certfile = "./certificates/server.pem" in
   let keyfile = "./certificates/server.key" in

--- a/examples/lwt/lwt_post.ml
+++ b/examples/lwt/lwt_post.ml
@@ -4,7 +4,7 @@ let response_handler notify_response_received response response_body =
   match Response.(response.status) with
   | `OK ->
     let rec read_response () =
-      Body.schedule_read
+      Body.Reader.schedule_read
         response_body
         ~on_eof:(fun () -> Lwt.wakeup_later notify_response_received ())
         ~on_read:(fun response_fragment ~off ~len ->
@@ -67,6 +67,6 @@ let () =
           ~error_handler
           ~response_handler
       in
-      Body.write_string request_body text_to_send;
-      Body.close_writer request_body;
+      Body.Writer.write_string request_body text_to_send;
+      Body.Writer.close request_body;
       response_received )

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -32,131 +32,154 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*)
 
-module Writer = Serialize.Writer
+module Reader = struct
+  type t =
+    { faraday : Faraday.t
+    ; mutable read_scheduled : bool
+    ; mutable on_eof : unit -> unit
+    ; mutable on_read : Bigstringaf.t -> off:int -> len:int -> unit
+    ; buffered_bytes : int ref
+    ; done_reading : int -> unit
+    }
 
-type _ t =
-  { faraday : Faraday.t
-  ; mutable read_scheduled : bool
-  ; mutable on_eof : unit -> unit
-  ; mutable on_read : Bigstringaf.t -> off:int -> len:int -> unit
-  ; buffered_bytes : int ref
-  ; done_reading : int -> unit
-  ; ready_to_write : unit -> unit
-  }
+  let default_done_reading = Sys.opaque_identity (fun _ -> ())
 
-let default_done_reading = Sys.opaque_identity (fun _ -> ())
+  let default_on_eof = Sys.opaque_identity (fun () -> ())
 
-let default_on_eof = Sys.opaque_identity (fun () -> ())
+  let default_on_read = Sys.opaque_identity (fun _ ~off:_ ~len:_ -> ())
 
-let default_on_read = Sys.opaque_identity (fun _ ~off:_ ~len:_ -> ())
+  let create buffer ~done_reading =
+    { faraday = Faraday.of_bigstring buffer
+    ; read_scheduled = false
+    ; on_eof = default_on_eof
+    ; on_read = default_on_read
+    ; buffered_bytes = ref 0
+    ; done_reading
+    }
 
-let _create buffer ~done_reading ~ready_to_write =
-  { faraday = Faraday.of_bigstring buffer
-  ; read_scheduled = false
-  ; on_eof = default_on_eof
-  ; on_read = default_on_read
-  ; buffered_bytes = ref 0
-  ; done_reading
-  ; ready_to_write
-  }
+  let create_empty () =
+    let t = create Bigstringaf.empty ~done_reading:default_done_reading in
+    Faraday.close t.faraday;
+    t
 
-let create_reader = _create ~ready_to_write:ignore
+  let empty = create_empty ()
 
-let create_writer = _create ~done_reading:default_done_reading
+  let is_closed t = Faraday.is_closed t.faraday
 
-let create_empty () =
-  let t = create_reader Bigstringaf.empty ~done_reading:default_done_reading in
-  Faraday.close t.faraday;
-  t
+  let unsafe_faraday t = t.faraday
 
-let empty = create_empty ()
+  let rec do_execute_read t on_eof on_read =
+    match Faraday.operation t.faraday with
+    | `Yield ->
+      ()
+    | `Close ->
+      t.read_scheduled <- false;
+      t.on_eof <- default_on_eof;
+      t.on_read <- default_on_read;
+      on_eof ()
+    | `Writev [] ->
+      assert false
+    | `Writev (iovec :: _) ->
+      t.read_scheduled <- false;
+      t.on_eof <- default_on_eof;
+      t.on_read <- default_on_read;
+      let { Httpaf.IOVec.buffer; off; len } = iovec in
+      Faraday.shift t.faraday len;
+      on_read buffer ~off ~len;
+      (* Application is done reading, we can give flow control tokens back to the
+       * peer. *)
+      t.done_reading len;
+      execute_read t
 
-let ready_to_write t = t.ready_to_write ()
+  and execute_read t =
+    if t.read_scheduled then do_execute_read t t.on_eof t.on_read
 
-let write_char t c =
-  Faraday.write_char t.faraday c;
-  ready_to_write t
+  let schedule_read t ~on_eof ~on_read =
+    if t.read_scheduled then
+      failwith "Body.schedule_read: reader already scheduled";
+    if is_closed t then
+      do_execute_read t on_eof on_read
+    else (
+      t.read_scheduled <- true;
+      t.on_eof <- on_eof;
+      t.on_read <- on_read)
 
-let write_string t ?off ?len s =
-  Faraday.write_string ?off ?len t.faraday s;
-  ready_to_write t
-
-let write_bigstring t ?off ?len b =
-  Faraday.write_bigstring ?off ?len t.faraday b;
-  ready_to_write t
-
-let schedule_bigstring t ?off ?len (b : Bigstringaf.t) =
-  Faraday.schedule_bigstring ?off ?len t.faraday b;
-  ready_to_write t
-
-let flush t kontinue =
-  Faraday.flush t.faraday kontinue;
-  ready_to_write t
-
-let is_closed t = Faraday.is_closed t.faraday
-
-let has_pending_output t = Faraday.has_pending_output t.faraday
-
-let close_writer t =
-  Faraday.close t.faraday;
-  ready_to_write t
-
-let unsafe_faraday t = t.faraday
-
-let rec do_execute_read t on_eof on_read =
-  match Faraday.operation t.faraday with
-  | `Yield ->
-    ()
-  | `Close ->
-    t.read_scheduled <- false;
-    t.on_eof <- default_on_eof;
-    t.on_read <- default_on_read;
-    on_eof ()
-  | `Writev [] ->
-    assert false
-  | `Writev (iovec :: _) ->
-    t.read_scheduled <- false;
-    t.on_eof <- default_on_eof;
-    t.on_read <- default_on_read;
-    let { Httpaf.IOVec.buffer; off; len } = iovec in
-    Faraday.shift t.faraday len;
-    on_read buffer ~off ~len;
-    (* Application is done reading, we can give flow control tokens back to the
-     * peer. *)
-    t.done_reading len;
+  let close t =
+    Faraday.close t.faraday;
     execute_read t
 
-and execute_read t =
-  if t.read_scheduled then do_execute_read t t.on_eof t.on_read
+  let has_pending_output t = Faraday.has_pending_output t.faraday
+end
 
-let schedule_read t ~on_eof ~on_read =
-  if t.read_scheduled then
-    failwith "Body.schedule_read: reader already scheduled";
-  if is_closed t then
-    do_execute_read t on_eof on_read
-  else (
-    t.read_scheduled <- true;
-    t.on_eof <- on_eof;
-    t.on_read <- on_read)
+module Writer = struct
+  module Writer = Serialize.Writer
 
-let close_reader t =
-  Faraday.close t.faraday;
-  execute_read t
+  type t =
+    { faraday : Faraday.t
+    ; buffered_bytes : int ref
+    ; ready_to_write : unit -> unit
+    }
 
-let transfer_to_writer t writer ~max_frame_size ~max_bytes stream_id =
-  let faraday = t.faraday in
-  match Faraday.operation faraday with
-  | `Yield | `Close ->
-    0
-  | `Writev iovecs ->
-    let buffered = t.buffered_bytes in
-    let iovecs = Httpaf.IOVec.shiftv iovecs !buffered in
-    let lengthv = Httpaf.IOVec.lengthv iovecs in
-    let writev_len = if max_bytes < lengthv then max_bytes else lengthv in
-    buffered := !buffered + writev_len;
-    let frame_info = Writer.make_frame_info ~max_frame_size stream_id in
-    Writer.schedule_iovecs writer frame_info ~len:writev_len iovecs;
-    Writer.flush writer (fun () ->
-        Faraday.shift faraday writev_len;
-        buffered := !buffered - writev_len);
-    writev_len
+  let create buffer ~ready_to_write =
+    { faraday = Faraday.of_bigstring buffer
+    ; buffered_bytes = ref 0
+    ; ready_to_write
+    }
+
+  let create_empty () =
+    let t = create Bigstringaf.empty ~ready_to_write:ignore in
+    Faraday.close t.faraday;
+    t
+
+  let empty = create_empty ()
+
+  let ready_to_write t = t.ready_to_write ()
+
+  let write_char t c =
+    Faraday.write_char t.faraday c;
+    ready_to_write t
+
+  let write_string t ?off ?len s =
+    Faraday.write_string ?off ?len t.faraday s;
+    ready_to_write t
+
+  let write_bigstring t ?off ?len b =
+    Faraday.write_bigstring ?off ?len t.faraday b;
+    ready_to_write t
+
+  let schedule_bigstring t ?off ?len (b : Bigstringaf.t) =
+    Faraday.schedule_bigstring ?off ?len t.faraday b;
+    ready_to_write t
+
+  let flush t kontinue =
+    Faraday.flush t.faraday kontinue;
+    ready_to_write t
+
+  let is_closed t = Faraday.is_closed t.faraday
+
+  let has_pending_output t = Faraday.has_pending_output t.faraday
+
+  let close t =
+    Faraday.close t.faraday;
+    ready_to_write t
+
+  let unsafe_faraday t = t.faraday
+
+  let transfer_to_writer t writer ~max_frame_size ~max_bytes stream_id =
+    let faraday = t.faraday in
+    match Faraday.operation faraday with
+    | `Yield | `Close ->
+      0
+    | `Writev iovecs ->
+      let buffered = t.buffered_bytes in
+      let iovecs = Httpaf.IOVec.shiftv iovecs !buffered in
+      let lengthv = Httpaf.IOVec.lengthv iovecs in
+      let writev_len = if max_bytes < lengthv then max_bytes else lengthv in
+      buffered := !buffered + writev_len;
+      let frame_info = Writer.make_frame_info ~max_frame_size stream_id in
+      Writer.schedule_iovecs writer frame_info ~len:writev_len iovecs;
+      Writer.flush writer (fun () ->
+          Faraday.shift faraday writev_len;
+          buffered := !buffered - writev_len);
+      writev_len
+end

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -1391,11 +1391,8 @@ let request
       ( Open WaitingForPeer
       , { request; request_body; response_handler; trailers_handler } );
   if not flush_headers_immediately then
-    Writer.yield t.writer
-  else
-    Writer.wakeup t.writer;
-  (* if flush_headers_immediately then *)
-  (* Writer.wakeup t.writer; *)
+    Writer.yield t.writer;
+  Writer.wakeup t.writer;
   (* Closing the request body puts the stream in the half-closed (local) state.
    * This is handled by {!Respd.flush_request_body}, which transitions the
    * state once it verifies that there's no more data to send for the

--- a/lib/h2.mli
+++ b/lib/h2.mli
@@ -327,73 +327,73 @@ end
 (** {2 Message Body} *)
 
 module Body : sig
-  type 'rw t
+  module Reader : sig
+    type t
 
-  val schedule_read
-    :  [ `read ] t
-    -> on_eof:(unit -> unit)
-    -> on_read:(Bigstringaf.t -> off:int -> len:int -> unit)
-    -> unit
-  (** [schedule_read t ~on_eof ~on_read] will setup [on_read] and [on_eof] as
-      callbacks for when bytes are available in [t] for the application to
-      consume, or when the input channel has been closed and no further bytes
-      will be received by the application.
+    val schedule_read
+      :  t
+      -> on_eof:(unit -> unit)
+      -> on_read:(Bigstringaf.t -> off:int -> len:int -> unit)
+      -> unit
+    (** [schedule_read t ~on_eof ~on_read] will setup [on_read] and [on_eof] as
+        callbacks for when bytes are available in [t] for the application to
+        consume, or when the input channel has been closed and no further bytes
+        will be received by the application.
 
-      Once either of these callbacks have been called, they become inactive. The
-      application is responsible for scheduling subsequent reads, either within
-      the [on_read] callback or by some other mechanism. *)
+        Once either of these callbacks have been called, they become inactive.
+        The application is responsible for scheduling subsequent reads, either
+        within the [on_read] callback or by some other mechanism. *)
 
-  val write_char : [ `write ] t -> char -> unit
-  (** [write_char w char] copies [char] into an internal buffer. If possible,
-      this write will be combined with previous and/or subsequent writes before
-      transmission. *)
+    val close : t -> unit
+    (** [close t] closes [t], indicating that any subsequent input received
+        should be discarded. *)
 
-  val write_string : [ `write ] t -> ?off:int -> ?len:int -> string -> unit
-  (** [write_string w ?off ?len str] copies [str] into an internal buffer. If
-      possible, this write will be combined with previous and/or subsequent
-      writes before transmission. *)
+    val is_closed : t -> bool
+    (** [is_closed t] is [true] if {!close} has been called on [t] and [false]
+        otherwise. A closed [t] may still have pending output. *)
+  end
 
-  val write_bigstring
-    :  [ `write ] t
-    -> ?off:int
-    -> ?len:int
-    -> Bigstringaf.t
-    -> unit
-  (** [write_bigstring w ?off ?len bs] copies [bs] into an internal buffer. If
-      possible, this write will be combined with previous and/or subsequent
-      writes before transmission. *)
+  module Writer : sig
+    type t
 
-  val schedule_bigstring
-    :  [ `write ] t
-    -> ?off:int
-    -> ?len:int
-    -> Bigstringaf.t
-    -> unit
-  (** [schedule_bigstring w ?off ?len bs] schedules [bs] to be transmitted at
-      the next opportunity without performing a copy. [bs] should not be
-      modified until a subsequent call to {!flush} has successfully completed. *)
+    val write_char : t -> char -> unit
+    (** [write_char w char] copies [char] into an internal buffer. If possible,
+        this write will be combined with previous and/or subsequent writes
+        before transmission. *)
 
-  val flush : [ `write ] t -> (unit -> unit) -> unit
-  (** [flush t f] makes all bytes in [t] available for writing to the awaiting
-      output channel. Once those bytes have reached that output channel, [f]
-      will be called.
+    val write_string : t -> ?off:int -> ?len:int -> string -> unit
+    (** [write_string w ?off ?len str] copies [str] into an internal buffer. If
+        possible, this write will be combined with previous and/or subsequent
+        writes before transmission. *)
 
-      The type of the output channel is runtime-dependent, as are guarantees
-      about whether those packets have been queued for delivery or have actually
-      been received by the intended recipient. *)
+    val write_bigstring : t -> ?off:int -> ?len:int -> Bigstringaf.t -> unit
+    (** [write_bigstring w ?off ?len bs] copies [bs] into an internal buffer. If
+        possible, this write will be combined with previous and/or subsequent
+        writes before transmission. *)
 
-  val close_reader : [ `read ] t -> unit
-  (** [close_reader t] closes [t], indicating that any subsequent input received
-      should be discarded. *)
+    val schedule_bigstring : t -> ?off:int -> ?len:int -> Bigstringaf.t -> unit
+    (** [schedule_bigstring w ?off ?len bs] schedules [bs] to be transmitted at
+        the next opportunity without performing a copy. [bs] should not be
+        modified until a subsequent call to {!flush} has successfully completed. *)
 
-  val close_writer : [ `write ] t -> unit
-  (** [close_writer t] closes [t], causing subsequent write calls to raise. If
-      [t] is writable, this will cause any pending output to become available to
-      the output channel. *)
+    val flush : t -> (unit -> unit) -> unit
+    (** [flush t f] makes all bytes in [t] available for writing to the awaiting
+        output channel. Once those bytes have reached that output channel, [f]
+        will be called.
 
-  val is_closed : _ t -> bool
-  (** [is_closed t] is [true] if {!close} has been called on [t] and [false]
-      otherwise. A closed [t] may still have pending output. *)
+        The type of the output channel is runtime-dependent, as are guarantees
+        about whether those packets have been queued for delivery or have
+        actually been received by the intended recipient. *)
+
+    val close : t -> unit
+    (** [close t] closes [t], causing subsequent write calls to raise. If [t] is
+        writable, this will cause any pending output to become available to the
+        output channel. *)
+
+    val is_closed : t -> bool
+    (** [is_closed t] is [true] if {!close} has been called on [t] and [false]
+        otherwise. A closed [t] may still have pending output. *)
+  end
 end
 
 (** {2 Message Types} *)
@@ -477,7 +477,7 @@ module Reqd : sig
 
   val request : t -> Request.t
 
-  val request_body : t -> [ `read ] Body.t
+  val request_body : t -> Body.Reader.t
 
   val response : t -> Response.t option
 
@@ -500,7 +500,7 @@ module Reqd : sig
     :  t
     -> ?flush_headers_immediately:bool
     -> Response.t
-    -> [ `write ] Body.t
+    -> Body.Writer.t
 
   val schedule_trailers : t -> Headers.t -> unit
   (** [schedule_trailers reqd trailers] schedules a list of trailers to be sent
@@ -696,7 +696,7 @@ module Server_connection : sig
   type request_handler = Reqd.t -> unit
 
   type error_handler =
-    ?request:Request.t -> error -> (Headers.t -> [ `write ] Body.t) -> unit
+    ?request:Request.t -> error -> (Headers.t -> Body.Writer.t) -> unit
 
   val create
     :  ?config:Config.t
@@ -808,7 +808,7 @@ module Client_connection : sig
 
   type trailers_handler = Headers.t -> unit
 
-  type response_handler = Response.t -> [ `read ] Body.t -> unit
+  type response_handler = Response.t -> Body.Reader.t -> unit
 
   type error_handler = error -> unit
 
@@ -854,7 +854,7 @@ module Client_connection : sig
     -> Request.t
     -> error_handler:error_handler
     -> response_handler:response_handler
-    -> [ `write ] Body.t
+    -> Body.Writer.t
   (** [request connection ?trailers_handler req ~error_handler
       ~response_handler]
       opens a new HTTP/2 stream with [req] and returns a request body that can

--- a/lib_test/test_h2_client.ml
+++ b/lib_test/test_h2_client.ml
@@ -330,7 +330,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -372,7 +372,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -411,7 +411,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -436,7 +436,7 @@ module Client_connection_tests = struct
         ~response_handler:second_response_handler
     in
     flush_request t;
-    Body.close_writer second_request_body;
+    Body.Writer.close second_request_body;
     let _, _ = flush_pending_writes t in
     let headers, continuation = header_and_continuation_frames in
     read_frames t [ headers; continuation ];
@@ -472,7 +472,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -521,7 +521,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -598,7 +598,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -707,7 +707,7 @@ module Client_connection_tests = struct
       "Stream is in the open state"
       true
       (Stream.is_open stream);
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -790,7 +790,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -876,7 +876,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let _, lenv = flush_pending_writes t in
     report_write_result t (`Ok lenv);
     let hpack_encoder = Hpack.Encoder.create 4096 in
@@ -901,7 +901,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let _, lenv = flush_pending_writes t in
     write_eof t;
     writer_closed t ~unread:lenv
@@ -923,7 +923,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     let frame = List.hd frames in
@@ -1001,8 +1001,8 @@ module Client_connection_tests = struct
     Alcotest.(check bool) "Response handler called" true !handler_called;
     Alcotest.(check bool) "error handler not called" false !error_handler_called;
     (* Send the rest of the request body. *)
-    Body.write_string request_body "hello";
-    Body.close_writer request_body;
+    Body.Writer.write_string request_body "hello";
+    Body.Writer.close request_body;
     writer_yielded t
 
   let test_connection_shutdown () =
@@ -1028,7 +1028,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer body;
+    Body.Writer.close body;
     let _frames, lenv = flush_pending_writes t in
     Alcotest.(check int) "Writer issues a zero-payload DATA frame" 9 lenv;
     report_write_result t (`Ok lenv);
@@ -1063,7 +1063,7 @@ module Client_connection_tests = struct
     let body_read_called = ref false in
     let body_eof_called = ref false in
     let response_handler _response response_body =
-      Body.schedule_read
+      Body.Reader.schedule_read
         response_body
         ~on_eof:ignore
         ~on_read:(fun _bs ~off:_ ~len:_ ->
@@ -1071,10 +1071,10 @@ module Client_connection_tests = struct
           Alcotest.(check bool)
             "Response body isn't closed (yet) when reading"
             false
-            (Body.is_closed response_body);
-          Body.schedule_read
+            (Body.Reader.is_closed response_body);
+          Body.Reader.schedule_read
             ~on_read:(fun _ ~off:_ ~len:_ ->
-              Body.schedule_read
+              Body.Reader.schedule_read
                 ~on_read:(fun _ ~off:_ ~len:_ -> ())
                 ~on_eof:(fun () -> body_eof_called := true)
                 response_body)
@@ -1090,7 +1090,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let _, lenv = flush_pending_writes t in
     report_write_result t (`Ok lenv);
     writer_yielded t;
@@ -1116,7 +1116,7 @@ module Client_connection_tests = struct
     let request = Request.create ~scheme:"http" `GET "/" in
     let body_read_called = ref false in
     let response_handler _response response_body =
-      Body.schedule_read
+      Body.Reader.schedule_read
         response_body
         ~on_eof:ignore
         ~on_read:(fun _bs ~off:_ ~len:_ -> body_read_called := true)
@@ -1130,7 +1130,7 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     flush_request t;
     let hpack_encoder = Hpack.Encoder.create 4096 in
     read_response
@@ -1167,9 +1167,9 @@ module Client_connection_tests = struct
         ~response_handler
     in
     flush_request t;
-    Body.write_string request_body "hello";
+    Body.Writer.write_string request_body "hello";
     flush_request t;
-    Body.flush request_body (fun () -> Body.close_writer request_body);
+    Body.Writer.flush request_body (fun () -> Body.Writer.close request_body);
     let frames, _lenv = flush_pending_writes t in
     Alcotest.(check (list int))
       "Writes empty DATA frame"
@@ -1202,7 +1202,7 @@ module Client_connection_tests = struct
     (* Writer yields when `~flush_headers_immediately` is false *)
     writer_yielded t;
     (* Write to the body *)
-    Body.write_string request_body "Hello";
+    Body.Writer.write_string request_body "Hello";
     let frames, lenv = flush_pending_writes t in
     Alcotest.(check (list int))
       "Batches headers and data frames together"
@@ -1212,7 +1212,7 @@ module Client_connection_tests = struct
            Frame.FrameType.serialize frame_type)
          frames);
     report_write_result t (`Ok lenv);
-    Body.close_writer request_body;
+    Body.Writer.close request_body;
     let frames, _lenv = flush_pending_writes t in
     Alcotest.(check (list int))
       "Writes empty DATA frame"

--- a/lwt/h2_lwt_intf.ml
+++ b/lwt/h2_lwt_intf.ml
@@ -72,7 +72,7 @@ module type Client = sig
     -> Request.t
     -> error_handler:Client_connection.error_handler
     -> response_handler:Client_connection.response_handler
-    -> [ `write ] Body.t
+    -> Body.Writer.t
 
   val ping : t -> ?payload:Bigstringaf.t -> ?off:int -> (unit -> unit) -> unit
 


### PR DESCRIPTION
This mirrors a [similar change](https://github.com/inhabitedtype/httpaf/pull/212) in http/af. Making the change in h2 has the benefit of unifying the interface between the 2 libs.