### PR TITLE
h2-async: expose more SSL client options

### DIFF
--- a/async/h2_async.ml
+++ b/async/h2_async.ml
@@ -156,9 +156,24 @@ module Client = struct
       >>| fun runtime -> { runtime; connection }
 
     let create_connection_with_default
-        ?(config = Config.default) ?push_handler ~error_handler socket
+        ?crt_file
+        ?key_file
+        ?ca_file
+        ?ca_path
+        ?verify_modes
+        ?(config = Config.default)
+        ?push_handler
+        ~error_handler
+        socket
       =
-      Client_runtime.create_default ~alpn_protocols:[ "http/1.1" ] socket
+      Client_runtime.create_default
+        ?crt_file
+        ?key_file
+        ?ca_file
+        ?ca_path
+        ?verify_modes
+        ~alpn_protocols:[ "http/1.1" ]
+        socket
       >>= fun ssl_client ->
       create_connection ~config ?push_handler ~error_handler ssl_client
 

--- a/async/h2_async.mli
+++ b/async/h2_async.mli
@@ -69,7 +69,18 @@ module Client : sig
       H2_async_intf.Client with type socket = Gluten_async.Client.SSL.socket
 
     val create_connection_with_default
-      :  ?config:Config.t
+      :  ?crt_file:string
+      -> ?key_file:string
+      -> ?ca_file:string
+      -> ?ca_path:string
+      -> ?verify_modes:
+           [< `Verify_client_once
+           | `Verify_fail_if_no_peer_ert
+           | `Verify_none
+           | `Verify_peer
+           ]
+           list
+      -> ?config:Config.t
       -> ?push_handler:
            (Request.t -> (Client_connection.response_handler, unit) result)
       -> error_handler:Client_connection.error_handler


### PR DESCRIPTION
This adds support for configuring Async_ssl client-side certificate options/verification modes. Helpful if you're accessing internal/non-public endpoints that have their own application-private CAs. This depends on https://github.com/anmonteiro/gluten/pull/27