### PR TITLE
Use a tail-recursive `Angstrom.skip_many`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ Unreleased
   ([#165](https://github.com/anmonteiro/ocaml-h2/pull/165))
 - h2: OCaml 5.00 compatibility -- add `seeded_hash` to `scheduler.ml`
   ([#168](https://github.com/anmonteiro/ocaml-h2/pull/168))
+- h2: Use a tail-recursive version of `Angstrom.skip_many`. Fixes a memory leak
+  in long-running connections e.g. gRPC
+  ([#172](https://github.com/anmonteiro/ocaml-h2/pull/172))
 
 0.8.0 2021-04-11
 ---------------

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -34,6 +34,18 @@
 
 open Angstrom
 
+(* We use the tail-recursive variant of `skip_many` from
+ * https://github.com/inhabitedtype/angstrom/pull/219 to avoid memory leaks in
+ * long-running connections. The original `skip_many` can build up a list of
+ * error handlers that may never be released. *)
+let skip_many p =
+  fix (fun m ->
+      p >>| (fun _ -> true) <|> return false >>= function
+      | true ->
+        m
+      | false ->
+        return ())
+
 let default_frame_header =
   { Frame.payload_length = 0
   ; flags = Flags.default_flags


### PR DESCRIPTION
@ansiwen reported seeing a memory leak while testing a long-running H2 client.

![image](https://user-images.githubusercontent.com/661909/166518097-28c879f5-836f-4b56-b6f4-50124163e8b9.png)

This could lead to memory leaks that can look like:

![image](https://user-images.githubusercontent.com/661909/166518152-7a1efc6a-7868-409c-b2e1-313cca7ef250.png)
