### PR TITLE
[H2.Serialize]: Demonstrate buffer sharing bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Unreleased
   ([#172](https://github.com/anmonteiro/ocaml-h2/pull/172))
 - h2-async: Add an OCaml-TLS client to `h2-async`
   ([#174](https://github.com/anmonteiro/ocaml-h2/pull/174))
+- h2: Fix a bug that caused different requests to share the same headers buffer
+  under concurrency ([#182](https://github.com/anmonteiro/ocaml-h2/pull/182))
 
 0.8.0 2021-04-11
 ---------------

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1659352118,
-        "narHash": "sha256-X/Tdlj/PYxcQg/1hcHXxdnDr5zLO22LohIudX+oT968=",
+        "lastModified": 1660220294,
+        "narHash": "sha256-l22Z88iegFq7xCLr1/jkgX9svnnWA7kTLgDOAi9iq6k=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3e1fff9ec0112fe5ec61ea7cc6d37c1720d865f8",
+        "rev": "825abbb40ed6b1e5e5fce95e2c21a1f5881ecf61",
         "type": "github"
       },
       "original": {

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -71,6 +71,14 @@ let encode_headers hpack_encoder headers =
   Serialize.Writer.encode_headers hpack_encoder f headers;
   Faraday.serialize_to_bigstring f
 
+let decode_headers decoder bigstring =
+  let parser = Angstrom.Buffered.parse (Hpack.Decoder.decode_headers decoder) in
+  let state = Angstrom.Buffered.feed parser (`Bigstring bigstring) in
+  let state' = Angstrom.Buffered.feed state `Eof in
+  match Angstrom.Buffered.state_to_option state' with
+  | Some (Ok headers) -> headers
+  | Some _ | None -> assert false
+
 let preface =
   let writer = Serialize.Writer.create 0x400 in
   Serialize.Writer.write_connection_preface writer [];

--- a/nix/ci/test.nix
+++ b/nix/ci/test.nix
@@ -5,7 +5,6 @@ let
   src = fetchGit {
     url = with lock.nodes.nixpkgs.locked; "https://github.com/${owner}/${repo}";
     inherit (lock.nodes.nixpkgs.locked) rev;
-    # inherit (lock.nodes.nixpkgs.original) ref;
     allRefs = true;
   };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,8 +12,7 @@ let
     with nix-filter; filter {
       root = ./..;
       include = [ "dune-project" ] ++ files ++ (builtins.map inDirectory dirs);
-    }
-  ;
+    };
   buildH2 = args: buildDunePackage ({
     version = "0.6.0-dev";
     useDune2 = true;


### PR DESCRIPTION

There's a bug in `H2.Serialize` related to sharing the underlying Faraday buffer that serializes headers in HPACK. It stems from the following piece of code:

https://github.com/anmonteiro/ocaml-h2/blob/e0f9abd52e76a684c1f9442f80c8e22e13eb0801/lib/serialize.ml#L473

- The current work in this PR just demonstrates how the bug can manifest itself.
- A subsequent commit will fix the bug