### PR TITLE
Fix array out of bounds in hpack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Unreleased
+-----------
+
+- hpack: fix a case where hpack would raise an array out of bounds exception
+  ([#183](https://github.com/anmonteiro/ocaml-h2/pull/183))
+  (@jonathanjameswatson)
+
 0.9.0 2022-08-14
 ---------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Unreleased
 
 - hpack: fix a case where hpack would raise an array out of bounds exception
   ([#183](https://github.com/anmonteiro/ocaml-h2/pull/183))
-  (@jonathanjameswatson)
+  ([@jonathanjameswatson]((https://github.com/jonathanjameswatson)))
 
 0.9.0 2022-08-14
 ---------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Unreleased
 
 - hpack: fix a case where hpack would raise an array out of bounds exception
   ([#183](https://github.com/anmonteiro/ocaml-h2/pull/183))
-  ([@jonathanjameswatson]((https://github.com/jonathanjameswatson)))
+  ([@jonathanjameswatson](https://github.com/jonathanjameswatson))
 
 0.9.0 2022-08-14
 ---------------

--- a/hpack/src/encoder.ml
+++ b/hpack/src/encoder.ml
@@ -113,7 +113,7 @@ let add ({ table; lookup_table; next_seq } as encoder) entry =
   encoder.next_seq <- next_seq + 1;
   HeaderFieldsTbl.replace lookup_table name map
 
-  let[@inline] find_token encoder without_indexing token name value =
+let[@inline] find_token encoder without_indexing token name value =
   let rec loop i =
     let value' =
       if i >= Static_table.table_size

--- a/hpack/test/test.ml
+++ b/hpack/test/test.ml
@@ -273,6 +273,26 @@ let test_evicting_table_size_0_followup () =
     hs
     decoded_headers
 
+let test_end_of_table () =
+  let hs =
+    [ { name = ":method"; value = "GET"; sensitive = false }
+    ; { name = "www-authenticate"; value = "Basic"; sensitive = false }
+    ]
+  in
+  let encoder = Encoder.create 60 in
+  let encoded_headers = encode_headers encoder hs in
+  Alcotest.(check bool)
+    "Encodes to non-zero hex"
+    true
+    (String.length encoded_headers > 0);
+  let decoder = Decoder.create 60 in
+  let decoded_headers = decode_headers decoder 60 encoded_headers in
+  List.iter2
+    (fun h1 h2 ->
+      Alcotest.(check header_testable "Decoded headers are roundtripped" h1 h2))
+    hs
+    decoded_headers
+
 let () =
   let fixtures_dir = "hpack-test-case" in
   let raw_data_dir = Filename.concat fixtures_dir "raw-data" in
@@ -297,5 +317,8 @@ let () =
        ; ( "Evictions from the dynamic table with 0 capacity (followup test)"
          , `Quick
          , test_evicting_table_size_0_followup )
+       ; ( "Encoding the header from the end of the static table"
+         , `Quick
+         , test_end_of_table )
        ] )
     :: suites)


### PR DESCRIPTION
This PR stops the server from hanging when a response has a non-empty www-authenticate header.

PS: I was not able to easily run ocamlformat for this PR, so you may need to run it.