### PR TITLE
Handle multiple RST_STREAM frames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Unreleased
 - hpack: fix a case where hpack would raise an array out of bounds exception
   ([#183](https://github.com/anmonteiro/ocaml-h2/pull/183))
   ([@jonathanjameswatson](https://github.com/jonathanjameswatson))
+- h2: (client) handle multiple RST_STREAM frames
+  ([#184](https://github.com/anmonteiro/ocaml-h2/pull/184))
+  ([@jonathanjameswatson](https://github.com/jonathanjameswatson))
 
 0.9.0 2022-08-14
 ---------------

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -761,6 +761,16 @@ let process_rst_stream_frame t { Frame.frame_header; _ } error_code =
        *)
       (* XXX(anmonteiro): When we add logging support, add something here. *)
       ()
+    | Closed _, Error_code.ProtocolError ->
+      (* From RFC7540§5.1:
+       *   Endpoints MUST ignore WINDOW_UPDATE or RST_STREAM frames received
+       *   in this state, though endpoints MAY choose to treat frames that
+       *   arrive a significant time after sending END_STREAM as a connection
+       *   error (Section 5.4.1) of type PROTOCOL_ERROR.
+       *
+       * We ignore further RST_STREAM frames.
+       *)
+      ()
     | Active _, Error_code.NoError ->
       (* If we're active (i.e. not done sending the request body), finish the
        * stream, in order to mark it for cleanup.

--- a/lib_test/test_h2_client.ml
+++ b/lib_test/test_h2_client.ml
@@ -1379,10 +1379,10 @@ module Client_connection_tests = struct
     ; "ping", `Quick, test_ping
     ; ( "stream level error handler called on RST_STREAM frames"
       , `Quick
-      , test_error_handler_double_rst_stream )
+      , test_error_handler_rst_stream )
     ; ( "stream level error handler called on two RST_STREAM frames"
       , `Quick
-      , test_error_handler_rst_stream_twice )
+      , test_error_handler_double_rst_stream )
     ; "starting an h2c connection", `Quick, test_h2c
     ; ( "non-zero `content-length` and no DATA frames"
       , `Quick

--- a/lib_test/test_h2_server.ml
+++ b/lib_test/test_h2_server.ml
@@ -1096,7 +1096,7 @@ module Server_connection_tests = struct
           ; flags = Flags.default_flags
           ; frame_type = RSTStream
           }
-      ; frame_payload = Frame.RSTStream Error_code.NoError
+      ; frame_payload = Frame.RSTStream Error_code.ProtocolError
       }
     in
     read_frames t [ data_frame; rst_stream; rst_stream ];

--- a/lib_test/test_h2_server.ml
+++ b/lib_test/test_h2_server.ml
@@ -1075,6 +1075,39 @@ module Server_connection_tests = struct
       true
       !body_eof_called
 
+  let test_rst_stream_frames () =
+    let t = create_and_handle_preface default_request_handler in
+    let request = Request.create ~scheme:"http" `GET "/" in
+    read_request ~body:"request body" t request;
+    let data_frame =
+      { Frame.frame_header =
+          { payload_length = 0
+          ; stream_id = 1l
+          ; flags = Flags.default_flags
+          ; frame_type = Data
+          }
+      ; frame_payload = Frame.Data (Bigstringaf.of_string ~off:0 ~len:3 "foo")
+      }
+    in
+    let rst_stream =
+      { Frame.frame_header =
+          { payload_length = 0
+          ; stream_id = 1l
+          ; flags = Flags.default_flags
+          ; frame_type = RSTStream
+          }
+      ; frame_payload = Frame.RSTStream Error_code.NoError
+      }
+    in
+    read_frames t [ data_frame; rst_stream; rst_stream ];
+    let window_update_and_response_frames =
+      next_write_operation t |> Write_operation.to_write_as_string |> Option.get
+    in
+    report_write_result
+      t
+      (`Ok (String.length window_update_and_response_frames));
+    writer_yields t
+
   let test_flow_control () =
     let body_read_called = ref false in
     let request = Request.create ~scheme:"http" `GET "/" in
@@ -1293,6 +1326,7 @@ module Server_connection_tests = struct
     ; ( "reading the request body as it arrives"
       , `Quick
       , test_reading_request_body )
+    ; "accepting multiple RST_STREAM frames", `Quick, test_rst_stream_frames
     ; "flow control", `Quick, test_flow_control
     ; ( "flow control -- can send empty data frame"
       , `Quick


### PR DESCRIPTION
When a client receives two RST_STREAM frames, a NYI exception is raised. This is not ideal, as servers are allowed to send multiple RST_STREAM frames.

From RFC7540§5.4.2:

> A RST_STREAM is the last frame that an endpoint can send on a stream. The peer that sends the RST_STREAM frame MUST be prepared to receive any frames that were sent or enqueued for sending by the remote peer. These frames can be ignored, except where they modify connection state (such as the state maintained for header compression Section 4.3 or flow control).
>
> Normally, an endpoint SHOULD NOT send more than one RST_STREAM frame for any stream.  However, an endpoint MAY send additional RST_STREAM frames if it receives frames on a closed stream after more than a round-trip time.  This behavior is permitted to deal with misbehaving implementations.

The first RST_STREAM frame should close the stream. In the closed state, extra RST_STREAM frames should be ignored (unless they arrive after a "significant" amount of time).

From RFC7540§5.1:

> Endpoints MUST ignore WINDOW_UPDATE or RST_STREAM frames received in this state, though endpoints MAY choose to treat frames that arrive a significant time after sending END_STREAM as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

Here is a relevant issue:

https://github.com/dotnet/aspnetcore/issues/32442

I have added a test for this problem, and will add a case to solve it soon.