### PR TITLE
[client]: Fix a race condition with ~flush_headers_immediately:false and empty request bodies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ Unreleased
 - h2: (client) handle multiple RST_STREAM frames
   ([#184](https://github.com/anmonteiro/ocaml-h2/pull/184))
   ([@jonathanjameswatson](https://github.com/jonathanjameswatson))
+- h2: (client) Fix a race condition with `~flush_headers_immediately:false` and
+  empty request bodies
+  ([#186](https://github.com/anmonteiro/ocaml-h2/pull/186))
 
 0.9.0 2022-08-14
 ---------------

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -148,6 +148,7 @@ module Writer = struct
   let has_pending_output t = Faraday.has_pending_output t.faraday
 
   let close t =
+    Serialize.Writer.unyield t.writer;
     Faraday.close t.faraday;
     ready_to_write t
 

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -111,22 +111,18 @@ module Writer = struct
   type t =
     { faraday : Faraday.t
     ; buffered_bytes : int ref
-    ; ready_to_write : unit -> unit
+    ; writer : Serialize.Writer.t
     }
 
-  let create buffer ~ready_to_write =
-    { faraday = Faraday.of_bigstring buffer
-    ; buffered_bytes = ref 0
-    ; ready_to_write
-    }
+  let create buffer ~writer =
+    { faraday = Faraday.of_bigstring buffer; buffered_bytes = ref 0; writer }
 
-  let create_empty () =
-    let t = create Bigstringaf.empty ~ready_to_write:ignore in
+  let create_empty ~writer =
+    let t = create Bigstringaf.empty ~writer in
     Faraday.close t.faraday;
     t
 
-  let empty = create_empty ()
-  let ready_to_write t = t.ready_to_write ()
+  let ready_to_write t = Serialize.Writer.wakeup t.writer
 
   let write_char t c =
     Faraday.write_char t.faraday c;

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -247,7 +247,7 @@ let handle_push_promise_headers t respd headers =
       | Ok response_handler ->
         (* From RFC7540§8.2:
          *   Promised requests [...] MUST NOT include a request body. *)
-        let request_body = Body.Writer.empty in
+        let request_body = Body.Writer.create_empty ~writer:t.writer in
         (* From RFC7540§5.1:
          *   reserved (remote): [...] Receiving a HEADERS frame causes the
          *   stream to transition to "half-closed (local)". *)
@@ -1359,7 +1359,7 @@ let create_h2c
              *   entirety before the client can send HTTP/2 frames. This means
              *   that a large request can block the use of the connection until
              *   it is completely sent. *)
-          ; request_body = Body.Writer.empty
+          ; request_body = Body.Writer.create_empty ~writer:t.writer
           ; response_handler
           ; trailers_handler = ignore
           } );
@@ -1378,9 +1378,7 @@ let request
   let max_frame_size = t.settings.max_frame_size in
   let respd = create_and_add_stream t ~error_handler in
   let request_body =
-    Body.Writer.create
-      (Bigstringaf.create max_frame_size)
-      ~ready_to_write:(fun () -> Writer.wakeup t.writer)
+    Body.Writer.create (Bigstringaf.create max_frame_size) ~writer:t.writer
   in
   let frame_info =
     Writer.make_frame_info

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -240,8 +240,7 @@ let send_streaming_response ~flush_headers_immediately t s response =
     in
     let response_body_buffer = Bigstringaf.create s.body_buffer_size in
     let response_body =
-      Body.Writer.create response_body_buffer ~ready_to_write:(fun () ->
-          Writer.wakeup t.writer)
+      Body.Writer.create response_body_buffer ~writer:t.writer
     in
     Writer.write_response_headers t.writer s.encoder frame_info response;
     if wait_for_first_flush then Writer.yield t.writer;

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -590,6 +590,12 @@ module Writer = struct
     Optional_thunk.call_if_some f
 
   let flush t f = flush t.encoder f
+
+  let unyield t =
+    (* Faraday doesn't have a function to take the serializer out of a yield
+       state. In the meantime, `flush` does it. *)
+    flush t (fun () -> ())
+
   let yield t = Faraday.yield t.encoder
   let close t = Faraday.close t.encoder
 


### PR DESCRIPTION
same thing we fixed in https://github.com/anmonteiro/httpaf/pull/110