### PR TITLE
[h2] scheduler: demonstrate bug removing active children streams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@ Unreleased
   commmunication channel
   ([#177](https://github.com/anmonteiro/ocaml-h2/pull/177),
   [#196](https://github.com/anmonteiro/ocaml-h2/pull/194))
+- h2: don't remove parent streams from the scheduler if they have children
+  ([#201](https://github.com/anmonteiro/ocaml-h2/pull/201))
 
 0.9.0 2022-08-14
 ---------------

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -492,25 +492,21 @@ let flush_response_body t ~max_bytes =
         0
     | Fixed ({ iovec = { buffer; off; len } as iovec; _ } as r)
       when max_bytes > 0 ->
-      if max_bytes < len
-      then (
-        let frame_info =
-          Writer.make_frame_info ~max_frame_size:t.max_frame_size t.id
+      let is_partial_flush = max_bytes < len in
+      let frame_info =
+        let flags =
+          if is_partial_flush
+          then Flags.default_flags
+          else Flags.(set_end_stream default_flags)
         in
-        write_buffer_data t.writer ~off ~len:max_bytes frame_info buffer;
-        r.iovec <- Httpaf.IOVec.shift iovec max_bytes;
-        max_bytes)
-      else
-        let frame_info =
-          Writer.make_frame_info
-            ~max_frame_size:t.max_frame_size
-            ~flags:Flags.(set_end_stream default_flags)
-            t.id
-        in
-        write_buffer_data t.writer ~off ~len frame_info buffer;
-        r.iovec <- Httpaf.IOVec.shift iovec len;
-        close_stream t;
-        len
+
+        Writer.make_frame_info ~max_frame_size:t.max_frame_size ~flags t.id
+      in
+      let len_to_write = if is_partial_flush then max_bytes else len in
+      write_buffer_data t.writer ~off ~len:len_to_write frame_info buffer;
+      r.iovec <- Httpaf.IOVec.shift iovec len_to_write;
+      if not is_partial_flush then close_stream t;
+      len_to_write
     | Fixed _ | Waiting | Complete _ -> 0)
   | _ -> 0
 

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -499,7 +499,6 @@ let flush_response_body t ~max_bytes =
           then Flags.default_flags
           else Flags.(set_end_stream default_flags)
         in
-
         Writer.make_frame_info ~max_frame_size:t.max_frame_size ~flags t.id
       in
       let len_to_write = if is_partial_flush then max_bytes else len in

--- a/lib/scheduler.ml
+++ b/lib/scheduler.ml
@@ -427,7 +427,11 @@ module Make (Streamd : StreamDescriptor) = struct
           let written = write t p_node in
           (* We check for activity again, because the stream may have gone
            * inactive after the call to `write` above. *)
-          written, Streamd.requires_output descriptor
+          let subtree_is_active =
+            Streamd.requires_output descriptor
+            || not (PriorityQueue.is_empty p.children)
+          in
+          written, subtree_is_active
         else (
           match PriorityQueue.pop p.children with
           | Some ((id, (Stream i as i_node)), children') ->


### PR DESCRIPTION
- fix an accounting bug for fixed size responses (shift all sent bytes for full responses)
- reveals a bug in the scheduler where children of a removed stream get erased from the tree completly