### PR TITLE
[h2] scheduler: don't add new streams as children of streams marked for removal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ Unreleased
   ([#200](https://github.com/anmonteiro/ocaml-h2/pull/200))
 - h2: don't remove parent streams from the scheduler if they have children
   ([#201](https://github.com/anmonteiro/ocaml-h2/pull/201))
+- h2: don't schedule streams as dependencies of others marked for removal
+  ([#205](https://github.com/anmonteiro/ocaml-h2/pull/205))
 
 0.9.0 2022-08-14
 ---------------

--- a/examples/alpn/lib/h2_handler.ml
+++ b/examples/alpn/lib/h2_handler.ml
@@ -6,7 +6,7 @@ let request_handler : Unix.sockaddr -> Reqd.t -> unit =
   let response_content_type =
     match Headers.get request.headers "Content-Type" with
     | Some request_content_type -> request_content_type
-    | None -> "application/octet-stream"
+    | None -> "text/plain"
   in
   let response =
     Response.create

--- a/examples/alpn/lib/http1_handler.ml
+++ b/examples/alpn/lib/http1_handler.ml
@@ -25,7 +25,7 @@ let request_handler : Unix.sockaddr -> Reqd.t Gluten.reqd -> unit =
   let response_content_type =
     match Headers.get request.headers "Content-Type" with
     | Some request_content_type -> request_content_type
-    | None -> "application/octet-stream"
+    | None -> "text/plain"
   in
   let response_body = "Welcome to an ALPN-negotiated HTTP/1.1 connection" in
   let response =

--- a/examples/alpn/mirage/h2_handler.ml
+++ b/examples/alpn/mirage/h2_handler.ml
@@ -6,7 +6,7 @@ let request_handler : Reqd.t -> unit =
   let response_content_type =
     match Headers.get headers "Content-Type" with
     | Some request_content_type -> request_content_type
-    | None -> "application/octet-stream"
+    | None -> "text/plain"
   in
   let response =
     Response.create
@@ -19,8 +19,8 @@ let request_handler : Reqd.t -> unit =
     "Welcome to an ALPN-negotiated HTTP/2 connection"
 
 let error_handler
-    : ?request:H2.Request.t -> _ -> (Headers.t -> [ `write ] Body.t) -> unit
+    : ?request:H2.Request.t -> _ -> (Headers.t -> Body.Writer.t) -> unit
   =
  fun ?request:_ _error start_response ->
   let response_body = start_response Headers.empty in
-  Body.close_writer response_body
+  Body.Writer.close response_body

--- a/examples/alpn/mirage/http1_handler.ml
+++ b/examples/alpn/mirage/http1_handler.ml
@@ -12,11 +12,11 @@ let redirect_handler : Reqd.t Gluten.reqd -> unit =
   Reqd.respond_with_string reqd response ""
 
 let redirect_error_handler
-    : ?request:Request.t -> _ -> (Headers.t -> [ `write ] Body.t) -> unit
+    : ?request:Request.t -> _ -> (Headers.t ->  Body.Writer.t) -> unit
   =
  fun ?request:_ _error start_response ->
   let response_body = start_response Headers.empty in
-  Body.close_writer response_body
+  Body.Writer.close response_body
 
 let request_handler : Reqd.t Gluten.reqd -> unit =
  fun { Gluten.reqd; _ } ->
@@ -24,7 +24,7 @@ let request_handler : Reqd.t Gluten.reqd -> unit =
   let response_content_type =
     match Headers.get headers "Content-Type" with
     | Some request_content_type -> request_content_type
-    | None -> "application/octet-stream"
+    | None -> "text/plain"
   in
   let response_body = "Welcome to an ALPN-negotiated HTTP/1.1 connection" in
   let response =
@@ -39,8 +39,8 @@ let request_handler : Reqd.t Gluten.reqd -> unit =
   Reqd.respond_with_string reqd response response_body
 
 let error_handler
-    : ?request:Request.t -> _ -> (Headers.t -> [ `write ] Body.t) -> unit
+    : ?request:Request.t -> _ -> (Headers.t -> Body.Writer.t) -> unit
   =
  fun ?request:_ _error start_response ->
   let response_body = start_response Headers.empty in
-  Body.close_writer response_body
+  Body.Writer.close response_body

--- a/examples/alpn/mirage/unikernel.ml
+++ b/examples/alpn/mirage/unikernel.ml
@@ -82,10 +82,6 @@ struct
     Tls.Config.server
       ~alpn_protocols:[ "h2"; "http/1.1" ] (* accept h2 before http/1.1 *)
       ~certificates:(`Single certificate)
-      ~ciphers:
-        (List.filter
-           Tls.Ciphersuite.ciphersuite_tls12_only
-           Tls.Config.Ciphers.supported)
       ()
 
   let start _random stack keys c _clock =

--- a/examples/alpn/unix/alpn_server_tls.ml
+++ b/examples/alpn/unix/alpn_server_tls.ml
@@ -43,10 +43,6 @@ let start_https_server () =
                   ~alpn_protocols:[ "h2"; "http/1.1" ]
                     (* accept h2 before http/1.1 *)
                   ~certificates:(`Single certificate)
-                  ~ciphers:
-                    (List.filter
-                       Tls.Ciphersuite.ciphersuite_tls12_only
-                       Tls.Config.Ciphers.supported)
                   ()
               in
               Tls_lwt.Unix.server_of_fd config fd >>= fun tls_server ->

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       let
         pkgs = nixpkgs.legacyPackages."${system}".extend (self: super: {
           h2spec = super.callPackage ./nix/h2spec.nix { };
-          ocamlPackages = super.ocaml-ng.ocamlPackages_5_00;
+          ocamlPackages = super.ocaml-ng.ocamlPackages_5_0;
         });
       in
       rec {

--- a/lib/scheduler.ml
+++ b/lib/scheduler.ml
@@ -87,8 +87,7 @@ module Make (Streamd : StreamDescriptor) = struct
             mutable flow : Settings.WindowSize.t
           ; (* inbound flow control, what the client is allowed to send. *)
             mutable inflow : Settings.WindowSize.t
-          ; mutable marked_for_removal :
-              (Stream_identifier.t * Stream.closed) list
+          ; mutable marked_for_removal : Stream.closed StreamsTbl.t
           }
           -> root node
       | Stream :
@@ -135,7 +134,7 @@ module Make (Streamd : StreamDescriptor) = struct
       ; all_streams = StreamsTbl.create ~random:true capacity
       ; flow = Settings.WindowSize.default_initial_window_size
       ; inflow = Settings.WindowSize.default_initial_window_size
-      ; marked_for_removal = []
+      ; marked_for_removal = StreamsTbl.create ~random:true capacity
       }
 
   let create
@@ -159,8 +158,6 @@ module Make (Streamd : StreamDescriptor) = struct
       ; flow = initial_send_window_size
       ; inflow = initial_recv_window_size
       }
-
-  let pq_add stream_id node pq = PriorityQueue.add stream_id node pq
 
   let remove_from_parent (Parent parent) id =
     match parent with
@@ -209,7 +206,7 @@ module Make (Streamd : StreamDescriptor) = struct
          *   sole dependency of its parent stream, causing other dependencies
          *   to become dependent on the exclusive stream. *)
         PriorityQueue.sg stream_id stream_node)
-      else pq_add stream_id stream_node new_children
+      else PriorityQueue.add stream_id stream_node new_children
     in
     match new_parent_node with
     | Stream stream -> stream.children <- new_children
@@ -235,7 +232,15 @@ module Make (Streamd : StreamDescriptor) = struct
         match
           StreamsTbl.find_opt root.all_streams priority.stream_dependency
         with
-        | Some parent_stream -> Parent parent_stream, priority
+        | Some parent_stream ->
+          (match
+             StreamsTbl.mem root.marked_for_removal priority.stream_dependency
+           with
+          | true ->
+            (* A stream that is marked for removal is also not present in the
+               tree *)
+            Parent t, Priority.default_priority
+          | false -> Parent parent_stream, priority)
         | None ->
           (* From RFC7540§5.3.1:
            *   A dependency on a stream that is not currently in the tree —
@@ -295,7 +300,7 @@ module Make (Streamd : StreamDescriptor) = struct
     in
     let stream_id = Streamd.id descriptor in
     StreamsTbl.add root.all_streams stream_id stream;
-    root.children <- pq_add stream_id stream root.children;
+    root.children <- PriorityQueue.add stream_id stream root.children;
     if priority != Priority.default_priority
     then reprioritize_stream t ~priority stream;
     stream
@@ -356,7 +361,7 @@ module Make (Streamd : StreamDescriptor) = struct
     stream.t <- tlast_p + (n * 256 / stream.priority.weight)
 
   let mark_for_removal (Connection root) id closed =
-    root.marked_for_removal <- (id, closed) :: root.marked_for_removal
+    StreamsTbl.replace root.marked_for_removal id closed
 
   let implicitly_close_idle_stream descriptor max_seen_ids =
     let implicitly_close_stream descriptor =
@@ -448,24 +453,20 @@ module Make (Streamd : StreamDescriptor) = struct
     in
     let (Connection root) = t in
     ignore (schedule t);
-    root.marked_for_removal <-
-      List.fold_left
-        (fun acc (id, closed) ->
-          (* When a stream completes, i.e. doesn't require more output and
-           * enters the `Closed` state, we set a TTL value which represents the
-           * number of writer yields that the stream has before it is removed
-           * from the connection Hash Table. By doing this we avoid losing some
-           * potentially useful information regarding the stream's state at the
-           * cost of keeping it around for a little while longer. *)
-          if closed.Stream.ttl = 0
-          then (
-            StreamsTbl.remove root.all_streams id;
-            acc)
-          else (
-            closed.ttl <- closed.ttl - 1;
-            (id, closed) :: acc))
-        []
-        root.marked_for_removal
+    StreamsTbl.iter
+      (fun id closed ->
+        (* When a stream completes, i.e. doesn't require more output and
+         * enters the `Closed` state, we set a TTL value which represents the
+         * number of writer yields that the stream has before it is removed
+         * from the connection Hash Table. By doing this we avoid losing some
+         * potentially useful information regarding the stream's state at the
+         * cost of keeping it around for a little while longer. *)
+        if closed.Stream.ttl = 0
+        then (
+          StreamsTbl.remove root.marked_for_removal id;
+          StreamsTbl.remove root.all_streams id)
+        else closed.ttl <- closed.ttl - 1)
+      root.marked_for_removal
 
   (* XXX(anmonteiro): Consider using `optint` for this?
    * https://github.com/mirage/optint

--- a/lib/scheduler.ml
+++ b/lib/scheduler.ml
@@ -134,7 +134,7 @@ module Make (Streamd : StreamDescriptor) = struct
       ; all_streams = StreamsTbl.create ~random:true capacity
       ; flow = Settings.WindowSize.default_initial_window_size
       ; inflow = Settings.WindowSize.default_initial_window_size
-      ; marked_for_removal = StreamsTbl.create ~random:true capacity
+      ; marked_for_removal = StreamsTbl.create ~random:true 256
       }
 
   let create

--- a/lib_test/test_priority.ml
+++ b/lib_test/test_priority.ml
@@ -48,7 +48,7 @@ let repeat (Scheduler.PriorityTreeNode.Connection root) queue num =
         (* simulate writing 100 bytes *)
         root.t_last <- p.t;
         Scheduler.update_t p_node 100;
-        loop (Scheduler.pq_add k p_node q') (n - 1) (k :: acc)
+        loop (Scheduler.PriorityQueue.add k p_node q') (n - 1) (k :: acc)
   in
   loop queue num []
 


### PR DESCRIPTION
- when reprioritizing a stream that depends on another, we need to add it as a child of the root node if the stream is no longer in the scheduling tree
- we were not respecting that constraint for cases where a stream still exists in `all_streams` but has been marked for removal (and is no longer in the tree)