### PR TITLE
Fork when handling requests in h2_eio

### DIFF
--- a/eio/h2_eio.ml
+++ b/eio/h2_eio.ml
@@ -35,6 +35,7 @@ module Server = struct
       ?(config = H2.Config.default)
       ~request_handler
       ~error_handler
+      ~sw
       client_addr
       socket
     =
@@ -42,7 +43,9 @@ module Server = struct
       H2.Server_connection.create
         ~config
         ~error_handler:(error_handler client_addr)
-        (request_handler client_addr)
+        (fun reqd ->
+          Eio.Fiber.fork ~sw (fun () ->
+            request_handler client_addr reqd))
     in
     Gluten_eio.Server.create_connection_handler
       ~read_buffer_size:config.read_buffer_size

--- a/eio/h2_eio.mli
+++ b/eio/h2_eio.mli
@@ -36,6 +36,7 @@ module Server : sig
     -> request_handler:(Eio.Net.Sockaddr.stream -> H2.Reqd.t -> unit)
     -> error_handler:
          (Eio.Net.Sockaddr.stream -> H2.Server_connection.error_handler)
+    -> sw:Eio.Switch.t
     -> Eio.Net.Sockaddr.stream
     -> Eio.Flow.two_way
     -> unit


### PR DESCRIPTION
Otherwise, the request handler blocked gluten's runloop.