### PR TITLE
Add changes entries for #225 #215 #214 #212

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+Unreleased
+--------------
+
+- h2-eio: adapt to Eio v0.12
+  ([#225](https://github.com/anmonteiro/ocaml-h2/pull/225))
+- h2-eio: track sw for gluten
+  ([#215](https://github.com/anmonteiro/ocaml-h2/pull/215))
+- h2: Add hpack {= version} constraint
+  ([#214](https://github.com/anmonteiro/ocaml-h2/pull/214))
+- h2, hpack, h2-async: Add opam constraints for angstrom and gluten-async
+  ([#212](https://github.com/anmonteiro/ocaml-h2/pull/212))
+
 0.10.0 2023-03-17
 ---------------
 


### PR DESCRIPTION
I have omitted the chore task PRs from the changelog, as they didn't seem to be included before now.

I used the diff from https://github.com/anmonteiro/ocaml-h2/compare/0.10.0...master to find missing changes.