### PR TITLE
Don't require Unix in order to use mock sockets

### DIFF
--- a/eio/h2_eio.mli
+++ b/eio/h2_eio.mli
@@ -54,7 +54,7 @@ module Client : sig
          (H2.Request.t -> (H2.Client_connection.response_handler, unit) result)
     -> sw:Eio.Switch.t
     -> error_handler:H2.Client_connection.error_handler
-    -> Eio_unix.Net.stream_socket_ty Eio.Net.stream_socket
+    -> _ Eio.Net.stream_socket
     -> t
 
   val request :


### PR DESCRIPTION
I found this little thing in our fork 😄.