### PR TITLE
perf: raise default max frame size to 64 KiB

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -45,7 +45,7 @@ type t =
 let default =
   { (* This is effectively MAX_FRAME_SIZE, because the parser commits the frame
      * header to prevent backtracking, therefore the entire payload can fit the
-     * read buffer. The default is 16384, and can't be lower than that.
+     * read buffer. The default is 65536, and can't be lower than 16384.
      *
      * Note: h2 does not check that MAX_FRAME_SIZE is lower than 16384
      * octets. In the case that a lower value than permitted is set, peers will
@@ -57,7 +57,7 @@ let default =
      *   The initial value is 2^14 (16,384) octets. The value advertised by an
      *   endpoint MUST be between this initial value and the maximum allowed
      *   frame size (2^24-1 or 16,777,215 octets), inclusive. *)
-    read_buffer_size = Settings.default.max_frame_size
+    read_buffer_size = 0x10000
   ; (* Buffer size for request bodies *) request_body_buffer_size = 0x1000
   ; (* Buffer size for response bodies *) response_body_buffer_size = 0x1000
   ; enable_server_push = true

--- a/lib/h2.mli
+++ b/lib/h2.mli
@@ -665,7 +665,7 @@ module Config : sig
   type t =
     { read_buffer_size : int
       (** [read_buffer_size] specifies the size of the largest frame payload that
-        the sender is willing to receive, in octets. Defaults to [16384] *)
+        the sender is willing to receive, in octets. Defaults to [65536] *)
     ; request_body_buffer_size : int  (** Defaults to [4096] *)
     ; response_body_buffer_size : int  (** Defaults to [4096] *)
     ; enable_server_push : bool  (** Defaults to [true] *)

--- a/lib_test/test_h2_client.ml
+++ b/lib_test/test_h2_client.ml
@@ -1346,7 +1346,12 @@ module Client_connection_tests = struct
          frames)
 
   let test_fragmented_request_body_chunking () =
-    let t = create_and_handle_preface () in
+    let config =
+      { Config.default with
+        read_buffer_size = Settings.default.max_frame_size
+      }
+    in
+    let t = create_and_handle_preface ~config () in
     let request = Request.create ~scheme:"http" `POST "/" in
     let response_handler _response _response_body = () in
     let request_body =

--- a/lib_test/test_h2_server.ml
+++ b/lib_test/test_h2_server.ml
@@ -940,6 +940,7 @@ module Server_connection_tests = struct
         = { Settings.default with
             enable_push = false
           ; max_concurrent_streams = 2l
+          ; max_frame_size = Config.default.read_buffer_size
           });
       (match next_write_operation t with
       | `Write iovecs ->


### PR DESCRIPTION
## Summary
- raise the default `Config.read_buffer_size` / advertised `SETTINGS_MAX_FRAME_SIZE` from `16 KiB` to `64 KiB`
- update config docs to match the new default
- make the affected tests explicit about whether they rely on the protocol minimum or the library default

## Why
On the large-upload benchmark, the server was still advertising the protocol-minimum `MAX_FRAME_SIZE` (`16 KiB`). That forces clients such as curl/nghttp2 to fragment a `1.5 GiB` upload into a very large number of DATA frames, which amplifies parser, flow-control, and write-loop overhead.

`64 KiB` was the best point I measured locally on this workload:
- `16 KiB`: much slower
- `64 KiB`: best throughput
- `256 KiB` and `1 MiB`: slightly worse again

So this is not just “bigger is better”; `64 KiB` looks like the right default tradeoff here.

## Validation
- `dune build --display=short @runtest-test_h2 @runtest-test_h2_client @runtest-test_h2_server spec/eio_h2spec.exe`
- all tests passed

## Benchmark
Using the existing `1.5 GiB` curl upload benchmark against the Eio server, with the same local `gluten` checkout in both variants:

- baseline (`perf/batch-window-updates`): `3.391s`, `452.94 MiB/s`; `3.409s`, `450.62 MiB/s`
- `64 KiB` default max frame size: `0.813s`, `1890.22 MiB/s`; `0.799s`, `1921.55 MiB/s`

This is roughly a `4.2x` throughput improvement on this workload.

## Notes
This changes the default connection preface behavior: default connections now send a non-empty SETTINGS frame advertising a larger `MAX_FRAME_SIZE`. The tests updated here cover the two places that were implicitly assuming the old `16 KiB` default.